### PR TITLE
Fix typo in node-empty-agent docker

### DIFF
--- a/.github/workflows/cd-samples.yml
+++ b/.github/workflows/cd-samples.yml
@@ -76,8 +76,8 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         working-directory: ./samples/basic/cards/nodejs/
         run: |
-          docker tag node-cards-bot:1.0.0 sdkagents.azurecr.io/node-cards-bot:latest
-          docker push sdkagents.azurecr.io/node-cards-bot:latest
+          docker tag node-cards-agent:1.0.0 sdkagents.azurecr.io/node-cards-agent:latest
+          docker push sdkagents.azurecr.io/node-cards-agent:latest
 
       - name: Build docker iamge Node Skill bot
         working-directory: ./samples/complex/copilotstudio-skill/nodejs/

--- a/.github/workflows/cd-samples.yml
+++ b/.github/workflows/cd-samples.yml
@@ -63,7 +63,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         working-directory: ./samples/basic/empty-agent/nodejs/
         run: |
-          docker tag node-empty-agent:1.0.0 sdkagents.azurecr.io/empty-agent:latest
+          docker tag node-empty-agent:1.0.0 sdkagents.azurecr.io/node-empty-agent:latest
           docker push sdkagents.azurecr.io/node-empty-agent:latest
 
       - name: Build docker image Node Cards bot


### PR DESCRIPTION
This pull request includes a minor but important fix to the `cd-samples.yml` file. The change corrects the Docker image tag name to ensure consistency and prevent potential errors during the deployment process.

* [`.github/workflows/cd-samples.yml`](diffhunk://#diff-90a18003d5663374bf652989be3ef71f50399fce3f30ceb75955cd12625976f8L66-R66): Corrected the Docker image tag from `sdkagents.azurecr.io/empty-agent:latest` to `sdkagents.azurecr.io/node-empty-agent:latest`.