### PR TITLE
upd-samples-readme to include dotnet skill sample

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -14,4 +14,4 @@ To enable debugging, open this folder using Visual Studio Code (VSCode). Follow 
 | Basic   | Empty Agent | Simplest agent | [basic/empty-agent/nodejs](./basic/empty-agent/nodejs) | [basic/empty-agent/dotnet](./basic/empty-agent/dotnet) | TBD |
 | Basic   | Weather Agent | WeatherAgent with various orchestrator libs | (Using LangChain.js) [basic/weather-agent/nodejs](./basic/weather-agent/nodejs) | (Using Semantic Kernel) [basic/weatherbot/dotnet](./basic/weatherbot/dotnet) | TBD |
 | Basic   | Copilot Studio Client | Consume CopilotStudio Agent | [basic/copilotstudio-client/nodejs](./basic/copilotstudio-client/nodejs) | [basic/copilotstudio-client/dotnet](./basic/copilotstudio-client/dotnet) | TBD |
-| Complex | Copilot Studio Skill | Call the echo bot from a Copilot Studio skill | [complex/copilotstudio-skill/nodejs](./complex/copilotstudio-skill/nodejs) | TBD | TBD |
+| Complex | Copilot Studio Skill | Call the echo bot from a Copilot Studio skill | [complex/copilotstudio-skill/nodejs](./complex/copilotstudio-skill/nodejs) | [complex/copilotstudio-skill/dotnet](./complex/copilotstudio-skill/dotnet) | TBD |


### PR DESCRIPTION
This pull request updates the `samples/README.md` file to include a new link for the .NET implementation of the Copilot Studio Skill.

Documentation update:

* Added a link to the .NET implementation of the Copilot Studio Skill in the "Complex" section of the sample projects table. (`samples/README.md`, [samples/README.mdL17-R17](diffhunk://#diff-d6b7b43e3875c86bc3d2c93388ed6d6a9a75d68c5183dea5779a0a10d6942118L17-R17))