### PR TITLE
Enable nullable reference types and refactor code

### DIFF
--- a/samples/basic/authorization/auto-signin/dotnet/AspNetExtensions.cs
+++ b/samples/basic/authorization/auto-signin/dotnet/AspNetExtensions.cs
@@ -19,8 +19,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 
-namespace Microsoft.Agents.AspNetAuthentication;
-
 public static class AspNetExtensions
 {
     private static readonly ConcurrentDictionary<string, ConfigurationManager<OpenIdConnectConfiguration>> _openIdMetadataCache = new();
@@ -56,7 +54,7 @@ public static class AspNetExtensions
             return;
         }
 
-        services.AddAgentAspNetAuthentication(tokenValidationSection.Get<TokenValidationOptions>());
+        services.AddAgentAspNetAuthentication(tokenValidationSection.Get<TokenValidationOptions>()!);
     }
 
     /// <summary>
@@ -154,7 +152,7 @@ public static class AspNetExtensions
                         return;
                     }
 
-                    string[] parts = authorizationHeader?.Split(' ');
+                    string[] parts = authorizationHeader?.Split(' ')!;
                     if (parts.Length != 2 || parts[0] != "Bearer")
                     {
                         // Default to AadTokenValidation handling
@@ -164,7 +162,7 @@ public static class AspNetExtensions
                     }
 
                     JwtSecurityToken token = new(parts[1]);
-                    string issuer = token.Claims.FirstOrDefault(claim => claim.Type == AuthenticationConstants.IssuerClaim)?.Value;
+                    string issuer = token.Claims.FirstOrDefault(claim => claim.Type == AuthenticationConstants.IssuerClaim)?.Value!;
 
                     if (validationOptions.AzureBotServiceTokenHandling && AuthenticationConstants.BotFrameworkTokenIssuer.Equals(issuer))
                     {
@@ -209,17 +207,17 @@ public static class AspNetExtensions
 
     public class TokenValidationOptions
     {
-        public IList<string> Audiences { get; set; }
+        public IList<string>? Audiences { get; set; }
 
         /// <summary>
         /// TenantId of the Azure Bot.  Optional but recommended. 
         /// </summary>
-        public string TenantId { get; set; }
+        public string? TenantId { get; set; }
 
         /// <summary>
         /// Additional valid issuers.  Optional, in which case the Public Azure Bot Service issuers are used.
         /// </summary>
-        public IList<string> ValidIssuers { get; set; }
+        public IList<string>? ValidIssuers { get; set; }
 
         /// <summary>
         /// Can be omitted, in which case public Azure Bot Service and Azure Cloud metadata urls are used.
@@ -231,14 +229,14 @@ public static class AspNetExtensions
         /// </summary>
         /// <see cref="AuthenticationConstants.PublicAzureBotServiceOpenIdMetadataUrl"/>
         /// <see cref="AuthenticationConstants.GovAzureBotServiceOpenIdMetadataUrl"/>
-        public string AzureBotServiceOpenIdMetadataUrl { get; set; }
+        public string? AzureBotServiceOpenIdMetadataUrl { get; set; }
 
         /// <summary>
         /// Entra OpenIdMetadataUrl.  Optional, in which case default value depends on IsGov.
         /// </summary>
         /// <see cref="AuthenticationConstants.PublicOpenIdMetadataUrl"/>
         /// <see cref="AuthenticationConstants.GovOpenIdMetadataUrl"/>
-        public string OpenIdMetadataUrl { get; set; }
+        public string? OpenIdMetadataUrl { get; set; }
 
         /// <summary>
         /// Determines if Azure Bot Service tokens are handled.  Defaults to true and should always be true until Azure Bot Service sends Entra ID token.

--- a/samples/basic/authorization/auto-signin/dotnet/AuthAgent.cs
+++ b/samples/basic/authorization/auto-signin/dotnet/AuthAgent.cs
@@ -15,13 +15,13 @@ using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 
-
+namespace AutoSignIn;
 public class AuthAgent : AgentApplication
 {
     /// <summary>
     /// Default Sign In Name
     /// </summary>
-    private string _defaultDisplayName = "Unknown User";
+    private readonly string _defaultDisplayName = "Unknown User";
 
     /// <summary>
     /// Describes the agent registration for the Authorization Agent
@@ -83,7 +83,7 @@ public class AuthAgent : AgentApplication
             if (member.Id != turnContext.Activity.Recipient.Id)
             {
                 string displayName = await GetDisplayName(turnContext);
-                StringBuilder sb = new StringBuilder();
+                StringBuilder sb = new();
                 sb.AppendLine($"Welcome to the AutoSignIn Example, **{displayName}**!");
                 sb.AppendLine("This Agent automatically signs you in when you first connect.");
                 sb.AppendLine("You can use the following commands to interact with the agent:");
@@ -126,13 +126,13 @@ public class AuthAgent : AgentApplication
         }
 
         // Just to verify we in fact have two different tokens.  This wouldn't be needed in a production Agent and here just to verify sample setup.
-        if (await UserAuthorization.GetTurnTokenAsync(turnContext, UserAuthorization.DefaultHandlerName, cancellationToken: cancellationToken) == await UserAuthorization.GetTurnTokenAsync(turnContext, "me"))
+        if (await UserAuthorization.GetTurnTokenAsync(turnContext, UserAuthorization.DefaultHandlerName, cancellationToken: cancellationToken) == await UserAuthorization.GetTurnTokenAsync(turnContext, "me", cancellationToken))
         {
             await turnContext.SendActivityAsync($"It would seem '{UserAuthorization.DefaultHandlerName}' and 'me' are using the same OAuth Connection", cancellationToken: cancellationToken);
             return;
         }
 
-        var meInfo = $"Name: {displayName}\r\nJob Title: {graphInfo["jobTitle"].GetValue<string>()}\r\nEmail: {graphInfo["mail"].GetValue<string>()}";
+        var meInfo = $"Name: {displayName}\r\nJob Title: {graphInfo["jobTitle"]!.GetValue<string>()}\r\nEmail: {graphInfo["mail"]!.GetValue<string>()}";
         await turnContext.SendActivityAsync(meInfo, cancellationToken: cancellationToken);
     }
 
@@ -179,7 +179,7 @@ public class AuthAgent : AgentApplication
     {
         // Raise a notification to the user that the sign-in process failed.  In a production Agent, this would be used
         // to display alternative ways to get help, or in some cases transfer to a live agent.
-        await turnContext.SendActivityAsync($"Sign In: Failed to login to '{handlerName}': {response.Cause}/{response.Error.Message}", cancellationToken: cancellationToken);
+        await turnContext.SendActivityAsync($"Sign In: Failed to login to '{handlerName}': {response.Cause}/{response.Error!.Message}", cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -191,7 +191,7 @@ public class AuthAgent : AgentApplication
         var graphInfo = await GetGraphInfo(turnContext, UserAuthorization.DefaultHandlerName);
         if (graphInfo != null)
         {
-            displayName = graphInfo!["displayName"].GetValue<string>();
+            displayName = graphInfo!["displayName"]!.GetValue<string>();
         }
         return displayName;
     }
@@ -208,7 +208,7 @@ public class AuthAgent : AgentApplication
             if (response.IsSuccessStatusCode)
             {
                 var content = await response.Content.ReadAsStringAsync();
-                return JsonNode.Parse(content);
+                return JsonNode.Parse(content)!;
             }
         }
         catch (Exception ex)
@@ -216,6 +216,6 @@ public class AuthAgent : AgentApplication
             // Handle error response from Graph API
             System.Diagnostics.Trace.WriteLine($"Error getting display name: {ex.Message}");
         }
-        return null;
+        return null!;
     }
 }

--- a/samples/basic/authorization/auto-signin/dotnet/AutoSignIn.csproj
+++ b/samples/basic/authorization/auto-signin/dotnet/AutoSignIn.csproj
@@ -3,6 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/basic/authorization/auto-signin/dotnet/Program.cs
+++ b/samples/basic/authorization/auto-signin/dotnet/Program.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Agents.AspNetAuthentication;
+using AutoSignIn;
 using Microsoft.Agents.Builder;
 using Microsoft.Agents.Hosting.AspNetCore;
 using Microsoft.Agents.Storage;

--- a/samples/basic/authorization/obo-authorization/dotnet/AspNetExtensions.cs
+++ b/samples/basic/authorization/obo-authorization/dotnet/AspNetExtensions.cs
@@ -19,8 +19,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 
-namespace Microsoft.Agents.AspNetAuthentication;
-
 public static class AspNetExtensions
 {
     private static readonly ConcurrentDictionary<string, ConfigurationManager<OpenIdConnectConfiguration>> _openIdMetadataCache = new();
@@ -56,7 +54,7 @@ public static class AspNetExtensions
             return;
         }
 
-        services.AddAgentAspNetAuthentication(tokenValidationSection.Get<TokenValidationOptions>());
+        services.AddAgentAspNetAuthentication(tokenValidationSection.Get<TokenValidationOptions>()!);
     }
 
     /// <summary>
@@ -154,7 +152,7 @@ public static class AspNetExtensions
                         return;
                     }
 
-                    string[] parts = authorizationHeader?.Split(' ');
+                    string[] parts = authorizationHeader?.Split(' ')!;
                     if (parts.Length != 2 || parts[0] != "Bearer")
                     {
                         // Default to AadTokenValidation handling
@@ -164,7 +162,7 @@ public static class AspNetExtensions
                     }
 
                     JwtSecurityToken token = new(parts[1]);
-                    string issuer = token.Claims.FirstOrDefault(claim => claim.Type == AuthenticationConstants.IssuerClaim)?.Value;
+                    string issuer = token.Claims.FirstOrDefault(claim => claim.Type == AuthenticationConstants.IssuerClaim)?.Value!;
 
                     if (validationOptions.AzureBotServiceTokenHandling && AuthenticationConstants.BotFrameworkTokenIssuer.Equals(issuer))
                     {
@@ -209,17 +207,17 @@ public static class AspNetExtensions
 
     public class TokenValidationOptions
     {
-        public IList<string> Audiences { get; set; }
+        public IList<string>? Audiences { get; set; }
 
         /// <summary>
         /// TenantId of the Azure Bot.  Optional but recommended. 
         /// </summary>
-        public string TenantId { get; set; }
+        public string? TenantId { get; set; }
 
         /// <summary>
         /// Additional valid issuers.  Optional, in which case the Public Azure Bot Service issuers are used.
         /// </summary>
-        public IList<string> ValidIssuers { get; set; }
+        public IList<string>? ValidIssuers { get; set; }
 
         /// <summary>
         /// Can be omitted, in which case public Azure Bot Service and Azure Cloud metadata urls are used.
@@ -231,14 +229,14 @@ public static class AspNetExtensions
         /// </summary>
         /// <see cref="AuthenticationConstants.PublicAzureBotServiceOpenIdMetadataUrl"/>
         /// <see cref="AuthenticationConstants.GovAzureBotServiceOpenIdMetadataUrl"/>
-        public string AzureBotServiceOpenIdMetadataUrl { get; set; }
+        public string? AzureBotServiceOpenIdMetadataUrl { get; set; }
 
         /// <summary>
         /// Entra OpenIdMetadataUrl.  Optional, in which case default value depends on IsGov.
         /// </summary>
         /// <see cref="AuthenticationConstants.PublicOpenIdMetadataUrl"/>
         /// <see cref="AuthenticationConstants.GovOpenIdMetadataUrl"/>
-        public string OpenIdMetadataUrl { get; set; }
+        public string? OpenIdMetadataUrl { get; set; }
 
         /// <summary>
         /// Determines if Azure Bot Service tokens are handled.  Defaults to true and should always be true until Azure Bot Service sends Entra ID token.

--- a/samples/basic/authorization/obo-authorization/dotnet/OBOAuthorization.csproj
+++ b/samples/basic/authorization/obo-authorization/dotnet/OBOAuthorization.csproj
@@ -3,6 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/basic/authorization/obo-authorization/dotnet/Program.cs
+++ b/samples/basic/authorization/obo-authorization/dotnet/Program.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Agents.AspNetAuthentication;
 using Microsoft.Agents.Builder;
 using Microsoft.Agents.Builder.App;
 using Microsoft.Agents.CopilotStudio.Client;
@@ -45,7 +44,7 @@ builder.AddAgent(sp =>
 
         return new CopilotClient(
             settings,
-            sp.GetService<IHttpClientFactory>(),
+            sp.GetService<IHttpClientFactory>()!,
             tokenProviderFunction: async (s) =>
             {
                 // In this sample, the Azure Bot OAuth Connection is configured to return an 
@@ -106,7 +105,7 @@ builder.AddAgent(sp =>
     // Called when the OAuth flow fails
     app.UserAuthorization.OnUserSignInFailure(async (turnContext, turnState, handlerName, response, initiatingActivity, cancellationToken) =>
     {
-        await turnContext.SendActivityAsync($"SignIn failed with '{handlerName}': {response.Cause}/{response.Error.Message}", cancellationToken: cancellationToken);
+        await turnContext.SendActivityAsync($"SignIn failed with '{handlerName}': {response.Cause}/{response.Error!.Message}", cancellationToken: cancellationToken);
     });
 
     return app;

--- a/samples/basic/azureai-streaming-poem-agent/dotnet/AspNetExtensions.cs
+++ b/samples/basic/azureai-streaming-poem-agent/dotnet/AspNetExtensions.cs
@@ -19,8 +19,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 
-namespace Microsoft.Agents.AspNetAuthentication;
-
 public static class AspNetExtensions
 {
     private static readonly ConcurrentDictionary<string, ConfigurationManager<OpenIdConnectConfiguration>> _openIdMetadataCache = new();
@@ -56,7 +54,7 @@ public static class AspNetExtensions
             return;
         }
 
-        services.AddAgentAspNetAuthentication(tokenValidationSection.Get<TokenValidationOptions>());
+        services.AddAgentAspNetAuthentication(tokenValidationSection.Get<TokenValidationOptions>()!);
     }
 
     /// <summary>
@@ -154,7 +152,7 @@ public static class AspNetExtensions
                         return;
                     }
 
-                    string[] parts = authorizationHeader?.Split(' ');
+                    string[] parts = authorizationHeader?.Split(' ')!;
                     if (parts.Length != 2 || parts[0] != "Bearer")
                     {
                         // Default to AadTokenValidation handling
@@ -164,7 +162,7 @@ public static class AspNetExtensions
                     }
 
                     JwtSecurityToken token = new(parts[1]);
-                    string issuer = token.Claims.FirstOrDefault(claim => claim.Type == AuthenticationConstants.IssuerClaim)?.Value;
+                    string issuer = token.Claims.FirstOrDefault(claim => claim.Type == AuthenticationConstants.IssuerClaim)?.Value!;
 
                     if (validationOptions.AzureBotServiceTokenHandling && AuthenticationConstants.BotFrameworkTokenIssuer.Equals(issuer))
                     {
@@ -209,17 +207,17 @@ public static class AspNetExtensions
 
     public class TokenValidationOptions
     {
-        public IList<string> Audiences { get; set; }
+        public IList<string>? Audiences { get; set; }
 
         /// <summary>
         /// TenantId of the Azure Bot.  Optional but recommended. 
         /// </summary>
-        public string TenantId { get; set; }
+        public string? TenantId { get; set; }
 
         /// <summary>
         /// Additional valid issuers.  Optional, in which case the Public Azure Bot Service issuers are used.
         /// </summary>
-        public IList<string> ValidIssuers { get; set; }
+        public IList<string>? ValidIssuers { get; set; }
 
         /// <summary>
         /// Can be omitted, in which case public Azure Bot Service and Azure Cloud metadata urls are used.
@@ -231,14 +229,14 @@ public static class AspNetExtensions
         /// </summary>
         /// <see cref="AuthenticationConstants.PublicAzureBotServiceOpenIdMetadataUrl"/>
         /// <see cref="AuthenticationConstants.GovAzureBotServiceOpenIdMetadataUrl"/>
-        public string AzureBotServiceOpenIdMetadataUrl { get; set; }
+        public string? AzureBotServiceOpenIdMetadataUrl { get; set; }
 
         /// <summary>
         /// Entra OpenIdMetadataUrl.  Optional, in which case default value depends on IsGov.
         /// </summary>
         /// <see cref="AuthenticationConstants.PublicOpenIdMetadataUrl"/>
         /// <see cref="AuthenticationConstants.GovOpenIdMetadataUrl"/>
-        public string OpenIdMetadataUrl { get; set; }
+        public string? OpenIdMetadataUrl { get; set; }
 
         /// <summary>
         /// Determines if Azure Bot Service tokens are handled.  Defaults to true and should always be true until Azure Bot Service sends Entra ID token.

--- a/samples/basic/azureai-streaming-poem-agent/dotnet/Program.cs
+++ b/samples/basic/azureai-streaming-poem-agent/dotnet/Program.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Azure.AI.OpenAI;
-using Microsoft.Agents.AspNetAuthentication;
 using Microsoft.Agents.Builder;
 using Microsoft.Agents.Hosting.AspNetCore;
 using Microsoft.Agents.Storage;
@@ -23,8 +22,8 @@ builder.Services.AddHttpClient();
 builder.Services.AddTransient<ChatClient>(sp =>
 {
     return new AzureOpenAIClient(
-            new Uri(builder.Configuration["AIServices:AzureOpenAI:Endpoint"]),
-            new ApiKeyCredential(builder.Configuration["AIServices:AzureOpenAI:ApiKey"]))
+            new Uri(builder.Configuration["AIServices:AzureOpenAI:Endpoint"]!),
+            new ApiKeyCredential(builder.Configuration["AIServices:AzureOpenAI:ApiKey"]!))
     .GetChatClient(builder.Configuration["AIServices:AzureOpenAI:DeploymentName"]);
 });
 

--- a/samples/basic/azureai-streaming-poem-agent/dotnet/StreamingAgent.cs
+++ b/samples/basic/azureai-streaming-poem-agent/dotnet/StreamingAgent.cs
@@ -14,7 +14,7 @@ namespace StreamingMessageAgent;
 
 public class StreamingAgent : AgentApplication
 {
-    private ChatClient _chatClient;
+    private readonly ChatClient _chatClient;
 
     /// <summary>
     /// Example of a streaming response agent using the Azure OpenAI ChatClient.
@@ -90,7 +90,7 @@ public class StreamingAgent : AgentApplication
                 if (update.ContentUpdate.Count > 0)
                 {
                     if (!string.IsNullOrEmpty(update.ContentUpdate[0]?.Text))
-                        turnContext.StreamingResponse.QueueTextChunk(update.ContentUpdate[0]?.Text);
+                        turnContext.StreamingResponse.QueueTextChunk(update.ContentUpdate[0]?.Text!);
                 }
             }
         }

--- a/samples/basic/azureai-streaming-poem-agent/dotnet/StreamingMessageAgent.csproj
+++ b/samples/basic/azureai-streaming-poem-agent/dotnet/StreamingMessageAgent.csproj
@@ -4,6 +4,7 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>disable</ImplicitUsings>
+		<Nullable>enable</Nullable>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/basic/empty-agent/dotnet/AspNetExtensions.cs
+++ b/samples/basic/empty-agent/dotnet/AspNetExtensions.cs
@@ -56,7 +56,7 @@ public static class AspNetExtensions
             return;
         }
 
-        services.AddAgentAspNetAuthentication(tokenValidationSection.Get<TokenValidationOptions>());
+        services.AddAgentAspNetAuthentication(tokenValidationSection.Get<TokenValidationOptions>()!);
     }
 
     /// <summary>
@@ -154,7 +154,7 @@ public static class AspNetExtensions
                         return;
                     }
 
-                    string[] parts = authorizationHeader?.Split(' ');
+                    string[] parts = authorizationHeader?.Split(' ')!;
                     if (parts.Length != 2 || parts[0] != "Bearer")
                     {
                         // Default to AadTokenValidation handling
@@ -164,7 +164,7 @@ public static class AspNetExtensions
                     }
 
                     JwtSecurityToken token = new(parts[1]);
-                    string issuer = token.Claims.FirstOrDefault(claim => claim.Type == AuthenticationConstants.IssuerClaim)?.Value;
+                    string issuer = token.Claims.FirstOrDefault(claim => claim.Type == AuthenticationConstants.IssuerClaim)?.Value!;
 
                     if (validationOptions.AzureBotServiceTokenHandling && AuthenticationConstants.BotFrameworkTokenIssuer.Equals(issuer))
                     {
@@ -209,17 +209,17 @@ public static class AspNetExtensions
 
     public class TokenValidationOptions
     {
-        public IList<string> Audiences { get; set; }
+        public IList<string>? Audiences { get; set; }
 
         /// <summary>
         /// TenantId of the Azure Bot.  Optional but recommended. 
         /// </summary>
-        public string TenantId { get; set; }
+        public string? TenantId { get; set; }
 
         /// <summary>
         /// Additional valid issuers.  Optional, in which case the Public Azure Bot Service issuers are used.
         /// </summary>
-        public IList<string> ValidIssuers { get; set; }
+        public IList<string>? ValidIssuers { get; set; }
 
         /// <summary>
         /// Can be omitted, in which case public Azure Bot Service and Azure Cloud metadata urls are used.
@@ -231,14 +231,14 @@ public static class AspNetExtensions
         /// </summary>
         /// <see cref="AuthenticationConstants.PublicAzureBotServiceOpenIdMetadataUrl"/>
         /// <see cref="AuthenticationConstants.GovAzureBotServiceOpenIdMetadataUrl"/>
-        public string AzureBotServiceOpenIdMetadataUrl { get; set; }
+        public string? AzureBotServiceOpenIdMetadataUrl { get; set; }
 
         /// <summary>
         /// Entra OpenIdMetadataUrl.  Optional, in which case default value depends on IsGov.
         /// </summary>
         /// <see cref="AuthenticationConstants.PublicOpenIdMetadataUrl"/>
         /// <see cref="AuthenticationConstants.GovOpenIdMetadataUrl"/>
-        public string OpenIdMetadataUrl { get; set; }
+        public string? OpenIdMetadataUrl { get; set; }
 
         /// <summary>
         /// Determines if Azure Bot Service tokens are handled.  Defaults to true and should always be true until Azure Bot Service sends Entra ID token.

--- a/samples/basic/empty-agent/dotnet/EmptyAgent.csproj
+++ b/samples/basic/empty-agent/dotnet/EmptyAgent.csproj
@@ -4,14 +4,8 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>disable</ImplicitUsings>
+		<Nullable>enable</Nullable>
 	</PropertyGroup>
-
-	<ItemGroup>
-		<Compile Remove="wwwroot\**" />
-		<Content Remove="wwwroot\**" />
-		<EmbeddedResource Remove="wwwroot\**" />
-		<None Remove="wwwroot\**" />
-	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.2.*-*" />

--- a/samples/basic/weather-agent/dotnet/Agents/WeatherForecastAgent.cs
+++ b/samples/basic/weather-agent/dotnet/Agents/WeatherForecastAgent.cs
@@ -86,10 +86,10 @@ public class WeatherForecastAgent
         {
             string resultContent = sb.ToString();
             var jsonNode = JsonNode.Parse(resultContent);
-            WeatherForecastAgentResponse result = new WeatherForecastAgentResponse()
+            WeatherForecastAgentResponse result = new()
             {
-                Content = jsonNode["content"].ToString(),
-                ContentType = Enum.Parse<WeatherForecastAgentResponseContentType>(jsonNode["contentType"].ToString(), true)
+                Content = jsonNode!["content"]!.ToString(),
+                ContentType = Enum.Parse<WeatherForecastAgentResponseContentType>(jsonNode["contentType"]!.ToString(), true)
             };
             return result;
         }

--- a/samples/basic/weather-agent/dotnet/Agents/WeatherForecastAgentResponse.cs
+++ b/samples/basic/weather-agent/dotnet/Agents/WeatherForecastAgentResponse.cs
@@ -23,5 +23,5 @@ public class WeatherForecastAgentResponse
 
     [JsonPropertyName("content")]
     [Description("The content of the response, may be plain text, or JSON based adaptive card but must be a string.")]
-    public string Content { get; set; }
+    public string? Content { get; set; }
 }

--- a/samples/basic/weather-agent/dotnet/AspNetExtensions.cs
+++ b/samples/basic/weather-agent/dotnet/AspNetExtensions.cs
@@ -19,8 +19,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 
-namespace Microsoft.Agents.AspNetAuthentication;
-
 public static class AspNetExtensions
 {
     private static readonly ConcurrentDictionary<string, ConfigurationManager<OpenIdConnectConfiguration>> _openIdMetadataCache = new();
@@ -56,7 +54,7 @@ public static class AspNetExtensions
             return;
         }
 
-        services.AddAgentAspNetAuthentication(tokenValidationSection.Get<TokenValidationOptions>());
+        services.AddAgentAspNetAuthentication(tokenValidationSection.Get<TokenValidationOptions>()!);
     }
 
     /// <summary>
@@ -154,7 +152,7 @@ public static class AspNetExtensions
                         return;
                     }
 
-                    string[] parts = authorizationHeader?.Split(' ');
+                    string[] parts = authorizationHeader?.Split(' ')!;
                     if (parts.Length != 2 || parts[0] != "Bearer")
                     {
                         // Default to AadTokenValidation handling
@@ -164,7 +162,7 @@ public static class AspNetExtensions
                     }
 
                     JwtSecurityToken token = new(parts[1]);
-                    string issuer = token.Claims.FirstOrDefault(claim => claim.Type == AuthenticationConstants.IssuerClaim)?.Value;
+                    string issuer = token.Claims.FirstOrDefault(claim => claim.Type == AuthenticationConstants.IssuerClaim)?.Value!;
 
                     if (validationOptions.AzureBotServiceTokenHandling && AuthenticationConstants.BotFrameworkTokenIssuer.Equals(issuer))
                     {
@@ -209,17 +207,17 @@ public static class AspNetExtensions
 
     public class TokenValidationOptions
     {
-        public IList<string> Audiences { get; set; }
+        public IList<string>? Audiences { get; set; }
 
         /// <summary>
         /// TenantId of the Azure Bot.  Optional but recommended. 
         /// </summary>
-        public string TenantId { get; set; }
+        public string? TenantId { get; set; }
 
         /// <summary>
         /// Additional valid issuers.  Optional, in which case the Public Azure Bot Service issuers are used.
         /// </summary>
-        public IList<string> ValidIssuers { get; set; }
+        public IList<string>? ValidIssuers { get; set; }
 
         /// <summary>
         /// Can be omitted, in which case public Azure Bot Service and Azure Cloud metadata urls are used.
@@ -231,14 +229,14 @@ public static class AspNetExtensions
         /// </summary>
         /// <see cref="AuthenticationConstants.PublicAzureBotServiceOpenIdMetadataUrl"/>
         /// <see cref="AuthenticationConstants.GovAzureBotServiceOpenIdMetadataUrl"/>
-        public string AzureBotServiceOpenIdMetadataUrl { get; set; }
+        public string? AzureBotServiceOpenIdMetadataUrl { get; set; }
 
         /// <summary>
         /// Entra OpenIdMetadataUrl.  Optional, in which case default value depends on IsGov.
         /// </summary>
         /// <see cref="AuthenticationConstants.PublicOpenIdMetadataUrl"/>
         /// <see cref="AuthenticationConstants.GovOpenIdMetadataUrl"/>
-        public string OpenIdMetadataUrl { get; set; }
+        public string? OpenIdMetadataUrl { get; set; }
 
         /// <summary>
         /// Determines if Azure Bot Service tokens are handled.  Defaults to true and should always be true until Azure Bot Service sends Entra ID token.

--- a/samples/basic/weather-agent/dotnet/MyAgent.cs
+++ b/samples/basic/weather-agent/dotnet/MyAgent.cs
@@ -18,8 +18,8 @@ namespace WeatherAgent;
 
 public class MyAgent : AgentApplication
 {
-    private WeatherForecastAgent _weatherAgent;
-    private Kernel _kernel;
+    private WeatherForecastAgent? _weatherAgent;
+    private readonly Kernel _kernel;
 
     public MyAgent(AgentApplicationOptions options, Kernel kernel) : base(options)
     {
@@ -40,7 +40,7 @@ public class MyAgent : AgentApplication
         ];
 
         // Start a Streaming Process 
-        await turnContext.StreamingResponse.QueueInformativeUpdateAsync("Working on a response for you"); 
+        await turnContext.StreamingResponse.QueueInformativeUpdateAsync("Working on a response for you", cancellationToken); 
 
         ChatHistory chatHistory = turnState.GetValue("conversation.chatHistory", () => new ChatHistory());
         _weatherAgent = new WeatherForecastAgent(_kernel, serviceCollection.BuildServiceProvider());
@@ -59,7 +59,7 @@ public class MyAgent : AgentApplication
         switch (forecastResponse.ContentType)
         {
             case WeatherForecastAgentResponseContentType.Text:
-                turnContext.StreamingResponse.QueueTextChunk(forecastResponse.Content);
+                turnContext.StreamingResponse.QueueTextChunk(forecastResponse.Content!);
                 break;
             case WeatherForecastAgentResponseContentType.AdaptiveCard:
                 turnContext.StreamingResponse.FinalMessage = MessageFactory.Attachment(new Attachment()

--- a/samples/basic/weather-agent/dotnet/Plugins/DateTimePlugin.cs
+++ b/samples/basic/weather-agent/dotnet/Plugins/DateTimePlugin.cs
@@ -20,7 +20,7 @@ public class DateTimePlugin
     /// </example>
     /// <returns> The current date </returns>
     [KernelFunction, Description("Get the current date")]
-    public string Date(IFormatProvider formatProvider = null)
+    public string Date(IFormatProvider formatProvider = null!)
     {
         // Example: Sunday, 12 January, 2025
         string date = DateTimeOffset.Now.ToString("D", formatProvider);
@@ -36,7 +36,7 @@ public class DateTimePlugin
     /// </example>
     /// <returns> The current date </returns>
     [KernelFunction, Description("Get the current date")]
-    public string Today(IFormatProvider formatProvider = null) =>
+    public string Today(IFormatProvider formatProvider = null!) =>
         // Example: Sunday, 12 January, 2025
         this.Date(formatProvider);
 
@@ -48,7 +48,7 @@ public class DateTimePlugin
     /// </example>
     /// <returns> The current date and time in the local time zone </returns>
     [KernelFunction, Description("Get the current date and time in the local time zone")]
-    public string Now(IFormatProvider formatProvider = null) =>
+    public string Now(IFormatProvider formatProvider = null!) =>
         // Sunday, January 12, 2025 9:15 PM
         DateTimeOffset.Now.ToString("f", formatProvider);
 }

--- a/samples/basic/weather-agent/dotnet/Plugins/WeatherForecast.cs
+++ b/samples/basic/weather-agent/dotnet/Plugins/WeatherForecast.cs
@@ -8,7 +8,7 @@ public class WeatherForecast
     /// <summary>
     /// A date for the weather forecast
     /// </summary>
-    public string Date { get; set; }
+    public string? Date { get; set; }
 
     /// <summary>
     /// The temperature in Celsius

--- a/samples/basic/weather-agent/dotnet/Program.cs
+++ b/samples/basic/weather-agent/dotnet/Program.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Agents.AspNetAuthentication;
 using Microsoft.Agents.Builder;
 using Microsoft.Agents.Hosting.AspNetCore;
 using Microsoft.Agents.Storage;
@@ -30,9 +29,9 @@ builder.Services.AddKernel();
 if (builder.Configuration.GetSection("AIServices").GetValue<bool>("UseAzureOpenAI"))
 {
     builder.Services.AddAzureOpenAIChatCompletion(
-        deploymentName: builder.Configuration.GetSection("AIServices:AzureOpenAI").GetValue<string>("DeploymentName"),
-        endpoint: builder.Configuration.GetSection("AIServices:AzureOpenAI").GetValue<string>("Endpoint"),
-        apiKey: builder.Configuration.GetSection("AIServices:AzureOpenAI").GetValue<string>("ApiKey"));
+        deploymentName: builder.Configuration.GetSection("AIServices:AzureOpenAI").GetValue<string>("DeploymentName")!,
+        endpoint: builder.Configuration.GetSection("AIServices:AzureOpenAI").GetValue<string>("Endpoint")!,
+        apiKey: builder.Configuration.GetSection("AIServices:AzureOpenAI").GetValue<string>("ApiKey")!);
 
     //Use the Azure CLI (for local) or Managed Identity (for Azure running app) to authenticate to the Azure OpenAI service
     //credentials: new ChainedTokenCredential(
@@ -43,8 +42,8 @@ if (builder.Configuration.GetSection("AIServices").GetValue<bool>("UseAzureOpenA
 else
 {
     builder.Services.AddOpenAIChatCompletion(
-        modelId: builder.Configuration.GetSection("AIServices:OpenAI").GetValue<string>("ModelId"),
-        apiKey: builder.Configuration.GetSection("AIServices:OpenAI").GetValue<string>("ApiKey"));
+        modelId: builder.Configuration.GetSection("AIServices:OpenAI").GetValue<string>("ModelId")!,
+        apiKey: builder.Configuration.GetSection("AIServices:OpenAI").GetValue<string>("ApiKey")!);
 }
 
 // Add AgentApplicationOptions from appsettings section "AgentApplication".

--- a/samples/basic/weather-agent/dotnet/WeatherAgent.csproj
+++ b/samples/basic/weather-agent/dotnet/WeatherAgent.csproj
@@ -6,6 +6,7 @@
 		<ImplicitUsings>disable</ImplicitUsings>
 		<NoWarn>$(NoWarn);SKEXP0010</NoWarn>
 		<UserSecretsId>b842df34-390f-490d-9dc0-73909363ad16</UserSecretsId>
+		<Nullable>enable</Nullable>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/complex/copilotstudio-skill/dotnet/AspNetExtensions.cs
+++ b/samples/complex/copilotstudio-skill/dotnet/AspNetExtensions.cs
@@ -19,8 +19,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 
-namespace Microsoft.Agents.AspNetAuthentication;
-
 public static class AspNetExtensions
 {
     private static readonly ConcurrentDictionary<string, ConfigurationManager<OpenIdConnectConfiguration>> _openIdMetadataCache = new();
@@ -56,7 +54,7 @@ public static class AspNetExtensions
             return;
         }
 
-        services.AddAgentAspNetAuthentication(tokenValidationSection.Get<TokenValidationOptions>());
+        services.AddAgentAspNetAuthentication(tokenValidationSection.Get<TokenValidationOptions>()!);
     }
 
     /// <summary>
@@ -154,7 +152,7 @@ public static class AspNetExtensions
                         return;
                     }
 
-                    string[] parts = authorizationHeader?.Split(' ');
+                    string[] parts = authorizationHeader?.Split(' ')!;
                     if (parts.Length != 2 || parts[0] != "Bearer")
                     {
                         // Default to AadTokenValidation handling
@@ -164,7 +162,7 @@ public static class AspNetExtensions
                     }
 
                     JwtSecurityToken token = new(parts[1]);
-                    string issuer = token.Claims.FirstOrDefault(claim => claim.Type == AuthenticationConstants.IssuerClaim)?.Value;
+                    string issuer = token.Claims.FirstOrDefault(claim => claim.Type == AuthenticationConstants.IssuerClaim)?.Value!;
 
                     if (validationOptions.AzureBotServiceTokenHandling && AuthenticationConstants.BotFrameworkTokenIssuer.Equals(issuer))
                     {
@@ -209,17 +207,17 @@ public static class AspNetExtensions
 
     public class TokenValidationOptions
     {
-        public IList<string> Audiences { get; set; }
+        public IList<string>? Audiences { get; set; }
 
         /// <summary>
         /// TenantId of the Azure Bot.  Optional but recommended. 
         /// </summary>
-        public string TenantId { get; set; }
+        public string? TenantId { get; set; }
 
         /// <summary>
         /// Additional valid issuers.  Optional, in which case the Public Azure Bot Service issuers are used.
         /// </summary>
-        public IList<string> ValidIssuers { get; set; }
+        public IList<string>? ValidIssuers { get; set; }
 
         /// <summary>
         /// Can be omitted, in which case public Azure Bot Service and Azure Cloud metadata urls are used.
@@ -231,14 +229,14 @@ public static class AspNetExtensions
         /// </summary>
         /// <see cref="AuthenticationConstants.PublicAzureBotServiceOpenIdMetadataUrl"/>
         /// <see cref="AuthenticationConstants.GovAzureBotServiceOpenIdMetadataUrl"/>
-        public string AzureBotServiceOpenIdMetadataUrl { get; set; }
+        public string? AzureBotServiceOpenIdMetadataUrl { get; set; }
 
         /// <summary>
         /// Entra OpenIdMetadataUrl.  Optional, in which case default value depends on IsGov.
         /// </summary>
         /// <see cref="AuthenticationConstants.PublicOpenIdMetadataUrl"/>
         /// <see cref="AuthenticationConstants.GovOpenIdMetadataUrl"/>
-        public string OpenIdMetadataUrl { get; set; }
+        public string? OpenIdMetadataUrl { get; set; }
 
         /// <summary>
         /// Determines if Azure Bot Service tokens are handled.  Defaults to true and should always be true until Azure Bot Service sends Entra ID token.

--- a/samples/complex/copilotstudio-skill/dotnet/CopilotStudioEchoSkill.csproj
+++ b/samples/complex/copilotstudio-skill/dotnet/CopilotStudioEchoSkill.csproj
@@ -3,6 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/complex/copilotstudio-skill/dotnet/Program.cs
+++ b/samples/complex/copilotstudio-skill/dotnet/Program.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using CopilotStudioEchoSkill;
-using Microsoft.Agents.AspNetAuthentication;
 using Microsoft.Agents.Builder;
 using Microsoft.Agents.Hosting.AspNetCore;
 using Microsoft.Agents.Storage;


### PR DESCRIPTION
Our samples should be warning free. The AspNetExtensions.cs file will be copied to other projects, and VS uses nullable by default.

This PR fixes the nullable related warnings from the extension, and other places.

This commit introduces nullable reference types across various files, enhancing code safety by explicitly indicating which properties can be null. Key changes include:

- Updated `AspNetExtensions.cs` to use the null-forgiving operator `!` for method calls and property accesses.
- Changed a private field in `AuthAgent.cs` from mutable to readonly to prevent modification after initialization.
- Modified `WeatherForecastAgent` and `WeatherForecastAgentResponse` classes to use nullable types for properties.
- Updated project files (`.csproj`) to enable nullable reference types.
- Cleaned up `Program.cs` files by removing unnecessary using directives and ensuring configuration values are treated as non-nullable.
- Minor refactoring for improved readability and maintainability, including the use of target-typed `new()` expressions.

These changes collectively aim to improve code quality and maintainability.