### PR TITLE
python packages renaming -- sample updates

### DIFF
--- a/samples/python/README.md
+++ b/samples/python/README.md
@@ -10,3 +10,34 @@
 |Copilot Studio Client|Console app to consume a Copilot Studio Agent|[copilotstudio-client](copilotstudio-client/README.md)|
 |Cards Agent|Agent that uses rich cards to enhance conversation design |[cards](cards/README.md)|
 |Copilot Studio Skill|Call the echo bot from a Copilot Studio skill |[copilotstudio-skill](copilotstudio-skill/README.md)|
+
+## Important Notice - Import Changes
+
+> **⚠️ Breaking Change**: Recent updates have changed the Python import structure from `microsoft.agents` to `microsoft_agents` (using underscores instead of dots). Please update your imports accordingly.
+
+### Import Examples
+
+```python
+# Activity types and models
+from microsoft_agents.activity import Activity
+
+# Core hosting functionality
+from microsoft_agents.hosting.core import TurnContext
+
+# aiohttp hosting
+from microsoft_agents.hosting.aiohttp import start_agent_process
+
+# Teams-specific functionality (compatible only with activity handler)
+from microsoft_agents.hosting.teams import TeamsActivityHandler
+
+# Azure Blob storage
+from microsoft_agents.storage.blob import BlobStorage
+
+# CosmosDB storage
+from microsoft_agents.storage.cosmos import CosmosDbStorage
+
+# MSAL authentication
+from microsoft_agents.authentication.msal import MsalAuth
+
+# Copilot Studio client
+from microsoft_agents.copilotstudio.client import CopilotClient

--- a/samples/python/auto-signin/src/agent.py
+++ b/samples/python/auto-signin/src/agent.py
@@ -6,7 +6,7 @@ import logging, json
 from os import environ, path
 from dotenv import load_dotenv
 
-from microsoft.agents.hosting.core import (
+from microsoft_agents.hosting.core import (
     Authorization,
     TurnContext,
     MessageFactory,
@@ -15,9 +15,9 @@ from microsoft.agents.hosting.core import (
     TurnState,
     MemoryStorage,
 )
-from microsoft.agents.activity import activity, load_configuration_from_env, ActivityTypes, Activity
-from microsoft.agents.hosting.aiohttp import CloudAdapter
-from microsoft.agents.authentication.msal import MsalConnectionManager
+from microsoft_agents.activity import load_configuration_from_env, ActivityTypes
+from microsoft_agents.hosting.aiohttp import CloudAdapter
+from microsoft_agents.authentication.msal import MsalConnectionManager
 
 from .github_api_client import get_current_profile, get_pull_requests
 from .user_graph_client import get_user_info

--- a/samples/python/auto-signin/src/cards.py
+++ b/samples/python/auto-signin/src/cards.py
@@ -1,4 +1,4 @@
-from microsoft.agents.hosting.core import CardFactory
+from microsoft_agents.hosting.core import CardFactory
 
 def create_profile_card(profile):
     return CardFactory.adaptive_card(

--- a/samples/python/auto-signin/src/main.py
+++ b/samples/python/auto-signin/src/main.py
@@ -4,7 +4,7 @@
 # enable logging for Microsoft Agents library
 # for more information, see README.md for Quickstart Agent
 import logging
-ms_agents_logger = logging.getLogger("microsoft.agents")
+ms_agents_logger = logging.getLogger("microsoft_agents")
 ms_agents_logger.addHandler(logging.StreamHandler())
 ms_agents_logger.setLevel(logging.INFO)
 

--- a/samples/python/auto-signin/src/start_server.py
+++ b/samples/python/auto-signin/src/start_server.py
@@ -1,6 +1,6 @@
 from os import environ
-from microsoft.agents.hosting.core import AgentApplication, AgentAuthConfiguration
-from microsoft.agents.hosting.aiohttp import (
+from microsoft_agents.hosting.core import AgentApplication, AgentAuthConfiguration
+from microsoft_agents.hosting.aiohttp import (
     start_agent_process,
     jwt_authorization_middleware,
     CloudAdapter,

--- a/samples/python/azureai-streaming/src/agent.py
+++ b/samples/python/azureai-streaming/src/agent.py
@@ -7,17 +7,17 @@ import logging
 from dotenv import load_dotenv
 from openai import AsyncAzureOpenAI
 
-from microsoft.agents.hosting.aiohttp import CloudAdapter
-from microsoft.agents.authentication.msal import MsalConnectionManager
+from microsoft_agents.hosting.aiohttp import CloudAdapter
+from microsoft_agents.authentication.msal import MsalConnectionManager
 
-from microsoft.agents.hosting.core import (
+from microsoft_agents.hosting.core import (
     Authorization,
     AgentApplication,
     TurnState,
     TurnContext,
     MemoryStorage,
 )
-from microsoft.agents.activity import (
+from microsoft_agents.activity import (
     load_configuration_from_env,
     Activity,
     ActivityTypes,

--- a/samples/python/azureai-streaming/src/main.py
+++ b/samples/python/azureai-streaming/src/main.py
@@ -4,7 +4,7 @@
 # enable logging for Microsoft Agents library
 # for more information, see README.md for Quickstart Agent
 import logging
-ms_agents_logger = logging.getLogger("microsoft.agents")
+ms_agents_logger = logging.getLogger("microsoft_agents")
 ms_agents_logger.addHandler(logging.StreamHandler())
 ms_agents_logger.setLevel(logging.INFO)
 

--- a/samples/python/azureai-streaming/src/start_server.py
+++ b/samples/python/azureai-streaming/src/start_server.py
@@ -1,6 +1,6 @@
 from os import environ
-from microsoft.agents.hosting.core import AgentApplication, AgentAuthConfiguration
-from microsoft.agents.hosting.aiohttp import (
+from microsoft_agents.hosting.core import AgentApplication, AgentAuthConfiguration
+from microsoft_agents.hosting.aiohttp import (
     start_agent_process,
     jwt_authorization_middleware,
     CloudAdapter,

--- a/samples/python/cards/src/agent.py
+++ b/samples/python/cards/src/agent.py
@@ -5,7 +5,7 @@ import json
 from os import environ
 from dotenv import load_dotenv
 
-from microsoft.agents.hosting.core import (
+from microsoft_agents.hosting.core import (
     Authorization,
     TurnContext,
     MemoryStorage,
@@ -14,9 +14,9 @@ from microsoft.agents.hosting.core import (
     MemoryStorage,
     MessageFactory,
 )
-from microsoft.agents.activity import load_configuration_from_env
-from microsoft.agents.hosting.aiohttp import CloudAdapter
-from microsoft.agents.authentication.msal import MsalConnectionManager
+from microsoft_agents.activity import load_configuration_from_env
+from microsoft_agents.hosting.aiohttp import CloudAdapter
+from microsoft_agents.authentication.msal import MsalConnectionManager
 
 from .card_messages import CardMessages
 

--- a/samples/python/cards/src/card_messages.py
+++ b/samples/python/cards/src/card_messages.py
@@ -1,7 +1,7 @@
-from microsoft.agents.activity import ActionTypes, Activity, ActivityTypes, Attachment
-from microsoft.agents.hosting.core import CardFactory, TurnContext
+from microsoft_agents.activity import ActionTypes, Activity, ActivityTypes, Attachment
+from microsoft_agents.hosting.core import CardFactory, TurnContext
 
-from microsoft.agents.activity import (
+from microsoft_agents.activity import (
     HeroCard,
     AnimationCard,
     AudioCard,

--- a/samples/python/cards/src/main.py
+++ b/samples/python/cards/src/main.py
@@ -4,7 +4,7 @@
 # enable logging for Microsoft Agents library
 # for more information, see README.md for Quickstart Agent
 import logging
-ms_agents_logger = logging.getLogger("microsoft.agents")
+ms_agents_logger = logging.getLogger("microsoft_agents")
 ms_agents_logger.addHandler(logging.StreamHandler())
 ms_agents_logger.setLevel(logging.INFO)
 

--- a/samples/python/cards/src/start_server.py
+++ b/samples/python/cards/src/start_server.py
@@ -1,6 +1,6 @@
 from os import environ
-from microsoft.agents.hosting.core import AgentApplication, AgentAuthConfiguration
-from microsoft.agents.hosting.aiohttp import (
+from microsoft_agents.hosting.core import AgentApplication, AgentAuthConfiguration
+from microsoft_agents.hosting.aiohttp import (
     start_agent_process,
     jwt_authorization_middleware,
     CloudAdapter,

--- a/samples/python/copilotstudio-client/src/main.py
+++ b/samples/python/copilotstudio-client/src/main.py
@@ -4,7 +4,7 @@
 # enable logging for Microsoft Agents library
 # for more information, see README.md for Quickstart Agent
 import logging
-ms_agents_logger = logging.getLogger("microsoft.agents")
+ms_agents_logger = logging.getLogger("microsoft_agents")
 ms_agents_logger.addHandler(logging.StreamHandler())
 ms_agents_logger.setLevel(logging.INFO)
 
@@ -17,8 +17,8 @@ from dotenv import load_dotenv
 
 from msal import PublicClientApplication
 
-from microsoft.agents.activity import ActivityTypes, load_configuration_from_env
-from microsoft.agents.copilotstudio.client import (
+from microsoft_agents.activity import ActivityTypes, load_configuration_from_env
+from microsoft_agents.copilotstudio.client import (
     ConnectionSettings,
     CopilotClient,
 )

--- a/samples/python/copilotstudio-skill/src/agent.py
+++ b/samples/python/copilotstudio-skill/src/agent.py
@@ -4,16 +4,16 @@
 from os import environ
 
 from dotenv import load_dotenv
-from microsoft.agents.hosting.core import (
+from microsoft_agents.hosting.core import (
     Authorization,
     AgentApplication,
     TurnState,
     TurnContext,
     MemoryStorage,
 )
-from microsoft.agents.activity import load_configuration_from_env
-from microsoft.agents.hosting.aiohttp import CloudAdapter
-from microsoft.agents.authentication.msal import MsalConnectionManager
+from microsoft_agents.activity import load_configuration_from_env
+from microsoft_agents.hosting.aiohttp import CloudAdapter
+from microsoft_agents.authentication.msal import MsalConnectionManager
 
 load_dotenv()
 agents_sdk_config = load_configuration_from_env(environ)

--- a/samples/python/copilotstudio-skill/src/main.py
+++ b/samples/python/copilotstudio-skill/src/main.py
@@ -4,14 +4,14 @@
 # enable logging for Microsoft Agents library
 # for more information, see README.md for Quickstart Agent
 import logging
-ms_agents_logger = logging.getLogger("microsoft.agents")
+ms_agents_logger = logging.getLogger("microsoft_agents")
 ms_agents_logger.addHandler(logging.StreamHandler())
 ms_agents_logger.setLevel(logging.INFO)
 
 from os import environ
 
-from microsoft.agents.hosting.core import AgentApplication
-from microsoft.agents.hosting.aiohttp import (
+from microsoft_agents.hosting.core import AgentApplication
+from microsoft_agents.hosting.aiohttp import (
     start_agent_process,
     jwt_authorization_middleware,
     CloudAdapter,

--- a/samples/python/obo-authorization/README.md
+++ b/samples/python/obo-authorization/README.md
@@ -3,7 +3,7 @@
 This Agent has been created using [Microsoft 365 Agents SDK](https://github.com/microsoft/agents-for-net), it shows how to use authorization in your Agent using OAuth and OBO.
 
 - The sample uses the Agent SDK User Authorization capabilities in [Azure Bot Service](https://docs.botframework.com), providing features to make it easier to develop an Agent that authorizes users with various identity providers such as Azure AD (Azure Active Directory), GitHub, Uber, etc.
-- This sample shows how to use an OBO Exchange to communicate with Microsoft Copilot Studio using the [CopilotClient class](https://learn.microsoft.com/python/api/microsoft-agents-copilotstudio-client/microsoft.agents.copilotstudio.client.copilotclient).
+- This sample shows how to use an OBO Exchange to communicate with Microsoft Copilot Studio using the [CopilotClient class](https://learn.microsoft.com/python/api/microsoft-agents-copilotstudio-client/microsoft_agents.copilotstudio.client.copilotclient).
 
 ## Prerequisites
 

--- a/samples/python/obo-authorization/src/agent.py
+++ b/samples/python/obo-authorization/src/agent.py
@@ -5,7 +5,7 @@ import re
 from os import environ
 from dotenv import load_dotenv
 
-from microsoft.agents.hosting.core import (
+from microsoft_agents.hosting.core import (
     Authorization,
     TurnContext,
     MemoryStorage,
@@ -13,10 +13,10 @@ from microsoft.agents.hosting.core import (
     TurnState,
     MemoryStorage,
 )
-from microsoft.agents.activity import load_configuration_from_env, ActivityTypes
-from microsoft.agents.hosting.aiohttp import CloudAdapter
-from microsoft.agents.authentication.msal import MsalConnectionManager
-from microsoft.agents.copilotstudio.client import ConnectionSettings, CopilotClient, PowerPlatformEnvironment, PowerPlatformCloud
+from microsoft_agents.activity import load_configuration_from_env, ActivityTypes
+from microsoft_agents.hosting.aiohttp import CloudAdapter
+from microsoft_agents.authentication.msal import MsalConnectionManager
+from microsoft_agents.copilotstudio.client import ConnectionSettings, CopilotClient, PowerPlatformEnvironment, PowerPlatformCloud
 
 # Load configuration from environment
 load_dotenv()

--- a/samples/python/obo-authorization/src/main.py
+++ b/samples/python/obo-authorization/src/main.py
@@ -4,7 +4,7 @@
 # enable logging for Microsoft Agents library
 # for more information, see README.md for Quickstart Agent
 import logging
-ms_agents_logger = logging.getLogger("microsoft.agents")
+ms_agents_logger = logging.getLogger("microsoft_agents")
 ms_agents_logger.addHandler(logging.StreamHandler())
 ms_agents_logger.setLevel(logging.INFO)
 

--- a/samples/python/obo-authorization/src/start_server.py
+++ b/samples/python/obo-authorization/src/start_server.py
@@ -1,6 +1,6 @@
 from os import environ
-from microsoft.agents.hosting.core import AgentApplication, AgentAuthConfiguration
-from microsoft.agents.hosting.aiohttp import (
+from microsoft_agents.hosting.core import AgentApplication, AgentAuthConfiguration
+from microsoft_agents.hosting.aiohttp import (
     start_agent_process,
     jwt_authorization_middleware,
     CloudAdapter,

--- a/samples/python/quickstart/README.md
+++ b/samples/python/quickstart/README.md
@@ -77,15 +77,15 @@ import logging
 logger = logging.getLogger(__name__)
 ```
 
-By using `__name__`, the logger for the module will have namespaces corresponding to the file structure. So, `microsoft.agents.hosting.core.app.agent_application.py` will initialize a new logger with the namespace `microsoft.agents.hosting.core.app.agent_application`, and any configurations to parent namespaces such as `microsoft.agents.hosting` or `microsoft` will apply to that new logger. By default, logging level for the `microsoft.agents.*` namespaces is set to `WARNING`, so logs emitted with levels above and equal to that are logged. By default, this would be `WARNING`, `ERROR`, and `CRITICAL`. Thus, by default `DEBUG` and `INFO` logs are ignored.
+By using `__name__`, the logger for the module will have namespaces corresponding to the file structure. So, `microsoft_agents.hosting.core.app.agent_application.py` will initialize a new logger with the namespace `microsoft_agents.hosting.core.app.agent_application`, and any configurations to parent namespaces such as `microsoft_agents.hosting` or `microsoft` will apply to that new logger. By default, logging level for the `microsoft_agents.*` namespaces is set to `WARNING`, so logs emitted with levels above and equal to that are logged. By default, this would be `WARNING`, `ERROR`, and `CRITICAL`. Thus, by default `DEBUG` and `INFO` logs are ignored.
 
 ### Configuration
 
-In these samples, we configure the logging for the `microsoft.agents` namespace with:
+In these samples, we configure the logging for the `microsoft_agents` namespace with:
 
 ```python
 import logging
-ms_agents_logger = logging.getLogger("microsoft.agents")
+ms_agents_logger = logging.getLogger("microsoft_agents")
 ms_agents_logger.addHandler(logging.StreamHandler())
 ms_agents_logger.setLevel(logging.INFO)
 ```
@@ -103,7 +103,7 @@ Acquiring token using Confidential Client Application.
 Meanwhile, here is an example that extends the configuration above to display logs in a more readable fashion by applying a formatter:
 ```python
 import logging
-ms_agents_logger = logging.getLogger("microsoft.agents")
+ms_agents_logger = logging.getLogger("microsoft_agents")
 console_handler = logging.StreamHandler()
 console_handler.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s (%(filename)s:%(lineno)d)"))
 ms_agents_logger.addHandler(console_handler)
@@ -115,9 +115,9 @@ Running the Quickstart Agent with this configuration will print something like f
 ```bash
 ======== Running on http://localhost:3978 ========
 (Press CTRL+C to quit)
-2025-08-06 09:39:24,539 - microsoft.agents.authentication.msal.msal_auth - INFO - Acquiring token using Confidential Client Application. (msal_auth.py:55)
-2025-08-06 09:39:24,658 - microsoft.agents.authentication.msal.msal_auth - INFO - Using cached client credentials for MSAL authentication. (msal_auth.py:117)
-2025-08-06 09:39:24,824 - microsoft.agents.authentication.msal.msal_auth - INFO - Acquiring token using Confidential Client Application. (msal_auth.py:55)
+2025-08-06 09:39:24,539 - microsoft_agents.authentication.msal.msal_auth - INFO - Acquiring token using Confidential Client Application. (msal_auth.py:55)
+2025-08-06 09:39:24,658 - microsoft_agents.authentication.msal.msal_auth - INFO - Using cached client credentials for MSAL authentication. (msal_auth.py:117)
+2025-08-06 09:39:24,824 - microsoft_agents.authentication.msal.msal_auth - INFO - Acquiring token using Confidential Client Application. (msal_auth.py:55)
 ...
 ```
 

--- a/samples/python/quickstart/src/agent.py
+++ b/samples/python/quickstart/src/agent.py
@@ -8,16 +8,16 @@ import traceback
 from dotenv import load_dotenv
 
 from os import environ
-from microsoft.agents.hosting.aiohttp import CloudAdapter
-from microsoft.agents.hosting.core import (
+from microsoft_agents.hosting.aiohttp import CloudAdapter
+from microsoft_agents.hosting.core import (
     Authorization,
     AgentApplication,
     TurnState,
     TurnContext,
     MemoryStorage,
 )
-from microsoft.agents.authentication.msal import MsalConnectionManager
-from microsoft.agents.activity import load_configuration_from_env
+from microsoft_agents.authentication.msal import MsalConnectionManager
+from microsoft_agents.activity import load_configuration_from_env
 
 load_dotenv()  # robrandao: todo
 agents_sdk_config = load_configuration_from_env(environ)

--- a/samples/python/quickstart/src/main.py
+++ b/samples/python/quickstart/src/main.py
@@ -4,7 +4,7 @@
 # enable logging for Microsoft Agents library
 # for more information, see README.md for Quickstart Agent
 import logging
-ms_agents_logger = logging.getLogger("microsoft.agents")
+ms_agents_logger = logging.getLogger("microsoft_agents")
 ms_agents_logger.addHandler(logging.StreamHandler())
 ms_agents_logger.setLevel(logging.INFO)
 

--- a/samples/python/quickstart/src/start_server.py
+++ b/samples/python/quickstart/src/start_server.py
@@ -1,6 +1,6 @@
 from os import environ
-from microsoft.agents.hosting.core import AgentApplication, AgentAuthConfiguration
-from microsoft.agents.hosting.aiohttp import (
+from microsoft_agents.hosting.core import AgentApplication, AgentAuthConfiguration
+from microsoft_agents.hosting.aiohttp import (
     start_agent_process,
     jwt_authorization_middleware,
     CloudAdapter,

--- a/samples/python/semantic-kernel-multiturn/src/app.py
+++ b/samples/python/semantic-kernel-multiturn/src/app.py
@@ -5,7 +5,7 @@ from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion
 from semantic_kernel.contents import ChatHistory
 
-from microsoft.agents.hosting.core import (
+from microsoft_agents.hosting.core import (
     Authorization,
     AgentApplication,
     TurnState,
@@ -13,10 +13,10 @@ from microsoft.agents.hosting.core import (
     MessageFactory,
     MemoryStorage,
 )
-from microsoft.agents.hosting.aiohttp import CloudAdapter
-from microsoft.agents.authentication.msal import MsalConnectionManager
+from microsoft_agents.hosting.aiohttp import CloudAdapter
+from microsoft_agents.authentication.msal import MsalConnectionManager
 
-from microsoft.agents.activity import Attachment, load_configuration_from_env
+from microsoft_agents.activity import Attachment, load_configuration_from_env
 
 from .agent import WeatherForecastAgent
 

--- a/samples/python/semantic-kernel-multiturn/src/main.py
+++ b/samples/python/semantic-kernel-multiturn/src/main.py
@@ -5,7 +5,7 @@
 # for more information, see README.md for Quickstart Agent
 import logging
 
-ms_agents_logger = logging.getLogger("microsoft.agents")
+ms_agents_logger = logging.getLogger("microsoft_agents")
 ms_agents_logger.addHandler(logging.StreamHandler())
 ms_agents_logger.setLevel(logging.INFO)
 

--- a/samples/python/semantic-kernel-multiturn/src/start_server.py
+++ b/samples/python/semantic-kernel-multiturn/src/start_server.py
@@ -1,6 +1,6 @@
 from os import environ
-from microsoft.agents.hosting.core import AgentApplication, AgentAuthConfiguration
-from microsoft.agents.hosting.aiohttp import (
+from microsoft_agents.hosting.core import AgentApplication, AgentAuthConfiguration
+from microsoft_agents.hosting.aiohttp import (
     start_agent_process,
     jwt_authorization_middleware,
     CloudAdapter,


### PR DESCRIPTION
This pull request introduces a breaking change to the Python import structure for the Microsoft Agents SDK samples, switching all imports from the dotted `microsoft.agents` format to the underscored `microsoft_agents` format. The change affects all sample projects, documentation, and logging configuration, and requires updating your code and logger namespaces accordingly.

**Breaking change: Python import structure**

* All SDK imports have been updated from `microsoft.agents` to `microsoft_agents` across every sample source file, including modules for activity, hosting, authentication, storage, and Copilot Studio client. [[1]](diffhunk://#diff-17e1d08aeeeae5470cb3b4fffd8238ca20661da4619b16a81077e8f456e07f0cL9-R9) [[2]](diffhunk://#diff-14292682a32055ebb361822e51060975ee14166cbe7d518f528c2b49886e91c6L10-R20) [[3]](diffhunk://#diff-35957ccf43303325be88b6ce9a485c4c4b7f42fd85b9cf7cf00f01a638ddfdcbL8-R8) [[4]](diffhunk://#diff-0be799c001d35197656f36fc2d4e4784789f1f2b8dd860702c58937cb61419aaL7-R16) [[5]](diffhunk://#diff-0ccb4d92163c46e4937d3443b3d065534b91bc15418246a5c55f7dd9fa1ff609L8-R19)
* The logging configuration in all samples now uses the `microsoft_agents` namespace instead of `microsoft.agents`, and documentation has been updated to reflect this change. [[1]](diffhunk://#diff-c0e8a007eca1f83a4f2a84b3a20b992fc96f0ebed9ffea6094415a7cf7795795L7-R7) [[2]](diffhunk://#diff-7629f44e57ea3524070ecf050623b1e55880e6477bda6ace0d1f7e6362a952ceL7-R7) [[3]](diffhunk://#diff-2aeb51f3bdb39e4a91d0ac669ed1826afe0eb2204bbd8a2ab14a79456d5229bbL7-R7) [[4]](diffhunk://#diff-de2b7f888509d20a9a3a9dacfb6a4a313f1cec0693278ca37c68911389b47326L7-R7) [[5]](diffhunk://#diff-ae669e562679ab18297474a53e75f2499523914767325e64311b20911b36b5b4L7-R14) [[6]](diffhunk://#diff-25eec6510b5f0fedf7a811e0a8c26d8b387d5dc3804b0cebc7f0c708a267448aL80-R88) [[7]](diffhunk://#diff-25eec6510b5f0fedf7a811e0a8c26d8b387d5dc3804b0cebc7f0c708a267448aL106-R106) [[8]](diffhunk://#diff-25eec6510b5f0fedf7a811e0a8c26d8b387d5dc3804b0cebc7f0c708a267448aL118-R120)

**Documentation updates**

* Added an "Important Notice" section to `samples/python/README.md` explaining the breaking import change and providing updated import examples for all major modules.
* Updated references in documentation to use the new `microsoft_agents` import path, including links and code snippets. [[1]](diffhunk://#diff-d4d472d8bb4d655e0ca7d17a2663e3f4c084d22734f0d628dd1b6533929d9bfbL6-R6) [[2]](diffhunk://#diff-b7979784104f52be7bb781e70c353d2239cf230008eb47e0f85f81c9e5c5a430R13-R43)

**Sample code consistency**

* All sample code files now consistently use the new import format, ensuring compatibility and reducing confusion for developers. [[1]](diffhunk://#diff-8e17780b86abcbc85ce5e89beff1cd0cbbab9f88a2729928b50d7236fc2ccc45L1-R1) [[2]](diffhunk://#diff-800d48867d8bd33650367a74010e4401d7f27b1caa8626bc4bf12a2f51f74439L1-R4) [[3]](diffhunk://#diff-35957ccf43303325be88b6ce9a485c4c4b7f42fd85b9cf7cf00f01a638ddfdcbL17-R19) [[4]](diffhunk://#diff-0be799c001d35197656f36fc2d4e4784789f1f2b8dd860702c58937cb61419aaL7-R16) [[5]](diffhunk://#diff-0ccb4d92163c46e4937d3443b3d065534b91bc15418246a5c55f7dd9fa1ff609L8-R19) [[6]](diffhunk://#diff-de2b7f888509d20a9a3a9dacfb6a4a313f1cec0693278ca37c68911389b47326L20-R21)

**Server and adapter initialization**

* All server startup scripts and adapter initializations have been updated to use the new import paths for agent application, authentication, and hosting modules. [[1]](diffhunk://#diff-9d9bd15ed3304bd1ae9eb1423437d66c7893cdff7381bcbdc433853780200c60L2-R3) [[2]](diffhunk://#diff-1d123dfe59b4e7f46c7ac7196a0698e03140eafd61006688f2bf739f3d51c2b5L2-R3) [[3]](diffhunk://#diff-a35e6c9f12d3776a8c46dcdd0e0f608566a1d50109361dd13b3d5626a56cabd2L2-R3)

Please ensure you update your codebase and any custom scripts to use `microsoft_agents` for all imports and logger configurations.