### PR TITLE
Updated calls to Authorization.sign_out to pass in State

### DIFF
--- a/samples/python/auto-signin/src/agent.py
+++ b/samples/python/auto-signin/src/agent.py
@@ -73,7 +73,7 @@ async def status(context: TurnContext, state: TurnState) -> bool:
 
 @AGENT_APP.message("/logout")
 async def logout(context: TurnContext, state: TurnState) -> None:
-    await AGENT_APP.auth.sign_out(context, state)
+    await AGENT_APP.auth.sign_out(context)
     await context.send_activity(MessageFactory.text("You have been logged out."))
 
 
@@ -105,7 +105,9 @@ async def pull_requests(context: TurnContext, state: TurnState) -> None:
 
         # prs = await get_pull_requests("microsoft", "agents", user_token_response.token)
         # as suggested by Copilot, using a public repository without SAML enforcement
-        prs = await get_pull_requests("octocat", "Hello-World", user_token_response.token)
+        prs = await get_pull_requests(
+            "octocat", "Hello-World", user_token_response.token
+        )
         for pr in prs:
             card = create_pr_card(pr)
             await context.send_activity(MessageFactory.attachment(card))

--- a/samples/python/obo-authorization/src/agent.py
+++ b/samples/python/obo-authorization/src/agent.py
@@ -16,7 +16,12 @@ from microsoft_agents.hosting.core import (
 from microsoft_agents.activity import load_configuration_from_env, ActivityTypes
 from microsoft_agents.hosting.aiohttp import CloudAdapter
 from microsoft_agents.authentication.msal import MsalConnectionManager
-from microsoft_agents.copilotstudio.client import ConnectionSettings, CopilotClient, PowerPlatformEnvironment, PowerPlatformCloud
+from microsoft_agents.copilotstudio.client import (
+    ConnectionSettings,
+    CopilotClient,
+    PowerPlatformEnvironment,
+    PowerPlatformCloud,
+)
 
 # Load configuration from environment
 load_dotenv()
@@ -36,8 +41,9 @@ AGENT_APP = AgentApplication[TurnState](
 # in practice, use a more robust method to manage app state with conversation state
 mcs_convo_id = None
 
+
 async def get_client(context: TurnContext) -> CopilotClient:
-    
+
     settings = ConnectionSettings(
         environment_id=environ.get("COPILOTSTUDIOAGENT__ENVIRONMENTID"),
         agent_identifier=environ.get("COPILOTSTUDIOAGENT__SCHEMANAME"),
@@ -54,13 +60,15 @@ async def get_client(context: TurnContext) -> CopilotClient:
 
     return mcs_client
 
+
 @AGENT_APP.message("/signout")
 async def signout(context: TurnContext, state: TurnState):
     # Force a user signout to reset the user state
-    # This is needed to reset the token in Azure Bot Services if needed. 
+    # This is needed to reset the token in Azure Bot Services if needed.
     # Typically this wouldn't be need in a production Agent.  Made available to assist it starting from scratch.
-    await AGENT_APP.auth.sign_out(context, state)
+    await AGENT_APP.auth.sign_out(context)
     await context.send_activity("You have signed out")
+
 
 # Since Auto SignIn is enabled, by the time this is called the token is already available via Authorization.get_token or
 # Authorization.exchange_token.


### PR DESCRIPTION
The interface for Authorization.sign_out has changed with the new OAuth refactor.