### PR TITLE
chore: update dependencies in Node.js samples

### DIFF
--- a/samples/nodejs/auto-signin/package-lock.json
+++ b/samples/nodejs/auto-signin/package-lock.json
@@ -56,19 +56,19 @@
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "15.11.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.11.0.tgz",
-      "integrity": "sha512-1IseGNH6XGWe+5xhZlhasTJP6Ob7tnVSlfFUnjdeH4Kik0n1SORTmdB6xxTwbx9Ro8EuO0XaRzpdABWSf15sdg==",
+      "version": "15.12.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.12.0.tgz",
+      "integrity": "sha512-4ucXbjVw8KJ5QBgnGJUeA07c8iznwlk5ioHIhI4ASXcXgcf2yRFhWzYOyWg/cI49LC9ekpFJeQtO3zjDTbl6TQ==",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.7.1.tgz",
-      "integrity": "sha512-ZTopY+BmE/OubqTXEQ5Eq+h6M5NKTchQBtvLj1tgiAf26lk2C+9jJTvtHjcyzE3iWn3wzySJLa4ArcjHJaZMQw==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.7.3.tgz",
+      "integrity": "sha512-MoJxkKM/YpChfq4g2o36tElyzNUMG8mfD6u8NbuaPAsqfGpaw249khAcJYNoIOigUzRw45OjXCOrexE6ImdUxg==",
       "dependencies": {
-        "@azure/msal-common": "15.11.0",
+        "@azure/msal-common": "15.12.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
@@ -77,17 +77,17 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
-      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@microsoft/agents-activity": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-activity/-/agents-activity-1.0.13.tgz",
-      "integrity": "sha512-G0QnQUN/QU0JBOsICRAVRSmFL7sboA2vSoFcWnL5fN5spqLcnXkNmiUhYJqSXDMZqqFWCnCq4jkcbxJD7v+w1g==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-activity/-/agents-activity-1.0.15.tgz",
+      "integrity": "sha512-1u8BVLsipsgTTte2SrR+LBXMkkU0oKteE6QDk+Dq5yTS4dF9266LPQ6HgOTNEk3PxRFSibrlw7zSO4y6S/d5wA==",
       "dependencies": {
         "debug": "^4.3.7",
         "uuid": "^11.1.0",
@@ -110,13 +110,13 @@
       }
     },
     "node_modules/@microsoft/agents-hosting": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting/-/agents-hosting-1.0.13.tgz",
-      "integrity": "sha512-pymWPGOvdZzMvtGmIZqpW7B0fgEZzquhhPJRU6g+XDvRy93S9OI5+Dwljk9xPPKJv57s/pNVeucxhcgMA67GHg==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting/-/agents-hosting-1.0.15.tgz",
+      "integrity": "sha512-f7fG0jOYH7UUmGkJT+Y7Hu4vrTrlbgsSGD18+I7H3XyrfOnAkjfwfhkd0BF6F4qCTqDokDXmcQuhlPj/w69k7w==",
       "dependencies": {
         "@azure/core-auth": "^1.10.0",
         "@azure/msal-node": "^3.7.0",
-        "@microsoft/agents-activity": "1.0.13",
+        "@microsoft/agents-activity": "1.0.15",
         "axios": "^1.11.0",
         "jsonwebtoken": "^9.0.2",
         "jwks-rsa": "^3.2.0"
@@ -126,11 +126,11 @@
       }
     },
     "node_modules/@microsoft/agents-hosting-express": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting-express/-/agents-hosting-express-1.0.13.tgz",
-      "integrity": "sha512-PywQFm1RmSBEkbRuPJ6H9a94TXNyJ1MCwtpTX6Le9VJEQVFKDDBwQrmziW7vXlBbyW+nWUBDH7XkQayhsrQK3Q==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting-express/-/agents-hosting-express-1.0.15.tgz",
+      "integrity": "sha512-MyepMCp58fFEWr64fS21XDUG1rwSh5z5H90JJm25aOfbkeTvKgypVI3sP2pCo2zGW68TORC91xrvRuxYGHEoMQ==",
       "dependencies": {
-        "@microsoft/agents-hosting": "1.0.13",
+        "@microsoft/agents-hosting": "1.0.15",
         "express": "^5.1.0"
       },
       "engines": {
@@ -260,9 +260,9 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
     "node_modules/@types/node": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
       "dependencies": {
         "undici-types": "~7.10.0"
       }
@@ -337,9 +337,9 @@
       }
     },
     "node_modules/adaptive-expressions": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/adaptive-expressions/-/adaptive-expressions-4.23.2.tgz",
-      "integrity": "sha512-L4A74wiDs/PSYF60CAw79jD1gBX7TXkNvBh/wYD/XIRAEBRi2Sb7sMZTbOzRGeYzGSD5wQZllynYXS+SDr31Lg==",
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/adaptive-expressions/-/adaptive-expressions-4.23.3.tgz",
+      "integrity": "sha512-7i1Ka6SR0gVcyHgoaZDiZi3BW3m9jN+lqfiMF6IY7SjugfeauXoZRl5sIDwJkYZNnffrfUuK7Pc3I3JiKfPBMw==",
       "peer": true,
       "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "~1.3.1",
@@ -548,9 +548,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.13",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
-      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "version": "1.11.18",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
+      "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==",
       "peer": true
     },
     "node_modules/debug": {
@@ -1239,11 +1239,12 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-      "engines": {
-        "node": ">=16"
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/proxy-addr": {
@@ -1286,17 +1287,32 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
+        "iconv-lite": "0.7.0",
         "unpipe": "1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/router": {

--- a/samples/nodejs/azure-ai-streaming/package-lock.json
+++ b/samples/nodejs/azure-ai-streaming/package-lock.json
@@ -148,19 +148,19 @@
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "15.11.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.11.0.tgz",
-      "integrity": "sha512-1IseGNH6XGWe+5xhZlhasTJP6Ob7tnVSlfFUnjdeH4Kik0n1SORTmdB6xxTwbx9Ro8EuO0XaRzpdABWSf15sdg==",
+      "version": "15.12.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.12.0.tgz",
+      "integrity": "sha512-4ucXbjVw8KJ5QBgnGJUeA07c8iznwlk5ioHIhI4ASXcXgcf2yRFhWzYOyWg/cI49LC9ekpFJeQtO3zjDTbl6TQ==",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.7.1.tgz",
-      "integrity": "sha512-ZTopY+BmE/OubqTXEQ5Eq+h6M5NKTchQBtvLj1tgiAf26lk2C+9jJTvtHjcyzE3iWn3wzySJLa4ArcjHJaZMQw==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.7.3.tgz",
+      "integrity": "sha512-MoJxkKM/YpChfq4g2o36tElyzNUMG8mfD6u8NbuaPAsqfGpaw249khAcJYNoIOigUzRw45OjXCOrexE6ImdUxg==",
       "dependencies": {
-        "@azure/msal-common": "15.11.0",
+        "@azure/msal-common": "15.12.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
@@ -169,9 +169,9 @@
       }
     },
     "node_modules/@microsoft/agents-activity": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-activity/-/agents-activity-1.0.13.tgz",
-      "integrity": "sha512-G0QnQUN/QU0JBOsICRAVRSmFL7sboA2vSoFcWnL5fN5spqLcnXkNmiUhYJqSXDMZqqFWCnCq4jkcbxJD7v+w1g==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-activity/-/agents-activity-1.0.15.tgz",
+      "integrity": "sha512-1u8BVLsipsgTTte2SrR+LBXMkkU0oKteE6QDk+Dq5yTS4dF9266LPQ6HgOTNEk3PxRFSibrlw7zSO4y6S/d5wA==",
       "dependencies": {
         "debug": "^4.3.7",
         "uuid": "^11.1.0",
@@ -202,13 +202,13 @@
       }
     },
     "node_modules/@microsoft/agents-hosting": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting/-/agents-hosting-1.0.13.tgz",
-      "integrity": "sha512-pymWPGOvdZzMvtGmIZqpW7B0fgEZzquhhPJRU6g+XDvRy93S9OI5+Dwljk9xPPKJv57s/pNVeucxhcgMA67GHg==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting/-/agents-hosting-1.0.15.tgz",
+      "integrity": "sha512-f7fG0jOYH7UUmGkJT+Y7Hu4vrTrlbgsSGD18+I7H3XyrfOnAkjfwfhkd0BF6F4qCTqDokDXmcQuhlPj/w69k7w==",
       "dependencies": {
         "@azure/core-auth": "^1.10.0",
         "@azure/msal-node": "^3.7.0",
-        "@microsoft/agents-activity": "1.0.13",
+        "@microsoft/agents-activity": "1.0.15",
         "axios": "^1.11.0",
         "jsonwebtoken": "^9.0.2",
         "jwks-rsa": "^3.2.0"
@@ -218,11 +218,11 @@
       }
     },
     "node_modules/@microsoft/agents-hosting-express": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting-express/-/agents-hosting-express-1.0.13.tgz",
-      "integrity": "sha512-PywQFm1RmSBEkbRuPJ6H9a94TXNyJ1MCwtpTX6Le9VJEQVFKDDBwQrmziW7vXlBbyW+nWUBDH7XkQayhsrQK3Q==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting-express/-/agents-hosting-express-1.0.15.tgz",
+      "integrity": "sha512-MyepMCp58fFEWr64fS21XDUG1rwSh5z5H90JJm25aOfbkeTvKgypVI3sP2pCo2zGW68TORC91xrvRuxYGHEoMQ==",
       "dependencies": {
-        "@microsoft/agents-hosting": "1.0.13",
+        "@microsoft/agents-hosting": "1.0.15",
         "express": "^5.1.0"
       },
       "engines": {
@@ -230,9 +230,9 @@
       }
     },
     "node_modules/@microsoft/m365agentsplayground": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/@microsoft/m365agentsplayground/-/m365agentsplayground-0.2.17.tgz",
-      "integrity": "sha512-nDcGCnvKUZ3ckI1fREgqFcFCGl7Xjlf4y9NqcgDVl6nMoV7i8SUzPZVl3Z4pCa/Qc4U4rGqlCN/YjhQzEfsHOg==",
+      "version": "0.2.18",
+      "resolved": "https://registry.npmjs.org/@microsoft/m365agentsplayground/-/m365agentsplayground-0.2.18.tgz",
+      "integrity": "sha512-8okNQ+fNQPPMBW/OSIudoCApBKqKxADNFIMivUGy/eaX9v8tFIG/gFo7DLwpaCzNuc1M8oOW9Sse1mX08Dxo0A==",
       "dev": true,
       "bin": {
         "agentsplayground": "cli.js",
@@ -316,9 +316,9 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
     "node_modules/@types/node": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
       "dependencies": {
         "undici-types": "~7.10.0"
       }
@@ -485,9 +485,9 @@
       }
     },
     "node_modules/chalk": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.0.tgz",
-      "integrity": "sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -1231,11 +1231,12 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-      "engines": {
-        "node": ">=16"
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/proxy-addr": {
@@ -1278,17 +1279,32 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
+        "iconv-lite": "0.7.0",
         "unpipe": "1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/react": {

--- a/samples/nodejs/cards/package-lock.json
+++ b/samples/nodejs/cards/package-lock.json
@@ -56,19 +56,19 @@
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "15.11.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.11.0.tgz",
-      "integrity": "sha512-1IseGNH6XGWe+5xhZlhasTJP6Ob7tnVSlfFUnjdeH4Kik0n1SORTmdB6xxTwbx9Ro8EuO0XaRzpdABWSf15sdg==",
+      "version": "15.12.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.12.0.tgz",
+      "integrity": "sha512-4ucXbjVw8KJ5QBgnGJUeA07c8iznwlk5ioHIhI4ASXcXgcf2yRFhWzYOyWg/cI49LC9ekpFJeQtO3zjDTbl6TQ==",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.7.1.tgz",
-      "integrity": "sha512-ZTopY+BmE/OubqTXEQ5Eq+h6M5NKTchQBtvLj1tgiAf26lk2C+9jJTvtHjcyzE3iWn3wzySJLa4ArcjHJaZMQw==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.7.3.tgz",
+      "integrity": "sha512-MoJxkKM/YpChfq4g2o36tElyzNUMG8mfD6u8NbuaPAsqfGpaw249khAcJYNoIOigUzRw45OjXCOrexE6ImdUxg==",
       "dependencies": {
-        "@azure/msal-common": "15.11.0",
+        "@azure/msal-common": "15.12.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
@@ -77,9 +77,9 @@
       }
     },
     "node_modules/@microsoft/agents-activity": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-activity/-/agents-activity-1.0.13.tgz",
-      "integrity": "sha512-G0QnQUN/QU0JBOsICRAVRSmFL7sboA2vSoFcWnL5fN5spqLcnXkNmiUhYJqSXDMZqqFWCnCq4jkcbxJD7v+w1g==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-activity/-/agents-activity-1.0.15.tgz",
+      "integrity": "sha512-1u8BVLsipsgTTte2SrR+LBXMkkU0oKteE6QDk+Dq5yTS4dF9266LPQ6HgOTNEk3PxRFSibrlw7zSO4y6S/d5wA==",
       "dependencies": {
         "debug": "^4.3.7",
         "uuid": "^11.1.0",
@@ -102,13 +102,13 @@
       }
     },
     "node_modules/@microsoft/agents-hosting": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting/-/agents-hosting-1.0.13.tgz",
-      "integrity": "sha512-pymWPGOvdZzMvtGmIZqpW7B0fgEZzquhhPJRU6g+XDvRy93S9OI5+Dwljk9xPPKJv57s/pNVeucxhcgMA67GHg==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting/-/agents-hosting-1.0.15.tgz",
+      "integrity": "sha512-f7fG0jOYH7UUmGkJT+Y7Hu4vrTrlbgsSGD18+I7H3XyrfOnAkjfwfhkd0BF6F4qCTqDokDXmcQuhlPj/w69k7w==",
       "dependencies": {
         "@azure/core-auth": "^1.10.0",
         "@azure/msal-node": "^3.7.0",
-        "@microsoft/agents-activity": "1.0.13",
+        "@microsoft/agents-activity": "1.0.15",
         "axios": "^1.11.0",
         "jsonwebtoken": "^9.0.2",
         "jwks-rsa": "^3.2.0"
@@ -118,9 +118,9 @@
       }
     },
     "node_modules/@microsoft/m365agentsplayground": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/@microsoft/m365agentsplayground/-/m365agentsplayground-0.2.17.tgz",
-      "integrity": "sha512-nDcGCnvKUZ3ckI1fREgqFcFCGl7Xjlf4y9NqcgDVl6nMoV7i8SUzPZVl3Z4pCa/Qc4U4rGqlCN/YjhQzEfsHOg==",
+      "version": "0.2.18",
+      "resolved": "https://registry.npmjs.org/@microsoft/m365agentsplayground/-/m365agentsplayground-0.2.18.tgz",
+      "integrity": "sha512-8okNQ+fNQPPMBW/OSIudoCApBKqKxADNFIMivUGy/eaX9v8tFIG/gFo7DLwpaCzNuc1M8oOW9Sse1mX08Dxo0A==",
       "dev": true,
       "bin": {
         "agentsplayground": "cli.js",
@@ -191,9 +191,9 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
     "node_modules/@types/node": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
       "dependencies": {
         "undici-types": "~7.10.0"
       }
@@ -2047,11 +2047,12 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-      "engines": {
-        "node": ">=16"
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/path-type": {
@@ -2136,17 +2137,32 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
+        "iconv-lite": "0.7.0",
         "unpipe": "1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/read-pkg": {

--- a/samples/nodejs/copilotstudio-client/package-lock.json
+++ b/samples/nodejs/copilotstudio-client/package-lock.json
@@ -20,19 +20,19 @@
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "15.11.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.11.0.tgz",
-      "integrity": "sha512-1IseGNH6XGWe+5xhZlhasTJP6Ob7tnVSlfFUnjdeH4Kik0n1SORTmdB6xxTwbx9Ro8EuO0XaRzpdABWSf15sdg==",
+      "version": "15.12.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.12.0.tgz",
+      "integrity": "sha512-4ucXbjVw8KJ5QBgnGJUeA07c8iznwlk5ioHIhI4ASXcXgcf2yRFhWzYOyWg/cI49LC9ekpFJeQtO3zjDTbl6TQ==",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.7.1.tgz",
-      "integrity": "sha512-ZTopY+BmE/OubqTXEQ5Eq+h6M5NKTchQBtvLj1tgiAf26lk2C+9jJTvtHjcyzE3iWn3wzySJLa4ArcjHJaZMQw==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.7.3.tgz",
+      "integrity": "sha512-MoJxkKM/YpChfq4g2o36tElyzNUMG8mfD6u8NbuaPAsqfGpaw249khAcJYNoIOigUzRw45OjXCOrexE6ImdUxg==",
       "dependencies": {
-        "@azure/msal-common": "15.11.0",
+        "@azure/msal-common": "15.12.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/@microsoft/agents-activity": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-activity/-/agents-activity-1.0.13.tgz",
-      "integrity": "sha512-G0QnQUN/QU0JBOsICRAVRSmFL7sboA2vSoFcWnL5fN5spqLcnXkNmiUhYJqSXDMZqqFWCnCq4jkcbxJD7v+w1g==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-activity/-/agents-activity-1.0.15.tgz",
+      "integrity": "sha512-1u8BVLsipsgTTte2SrR+LBXMkkU0oKteE6QDk+Dq5yTS4dF9266LPQ6HgOTNEk3PxRFSibrlw7zSO4y6S/d5wA==",
       "dependencies": {
         "debug": "^4.3.7",
         "uuid": "^11.1.0",
@@ -66,11 +66,11 @@
       }
     },
     "node_modules/@microsoft/agents-copilotstudio-client": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-copilotstudio-client/-/agents-copilotstudio-client-1.0.13.tgz",
-      "integrity": "sha512-k5nCUiEH5OvRQYHggwnAK14IkuudPdu8R9KjECVnZN98CS9lIg69klI8VgSpx8WQU45aDWkjNZ3+sRWJimZe1Q==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-copilotstudio-client/-/agents-copilotstudio-client-1.0.15.tgz",
+      "integrity": "sha512-pAMR6M5UKy7bAS9aHmsko6yuLky/7Aou6VpQ9MRCHzkKJCQEvoT57iGPip3E5H4C0EfPcW2/NkCW84+Y3hDTHw==",
       "dependencies": {
-        "@microsoft/agents-activity": "1.0.13",
+        "@microsoft/agents-activity": "1.0.15",
         "axios": "^1.9.0",
         "rxjs": "7.8.2",
         "uuid": "^11.1.0"
@@ -107,9 +107,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.17.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.2.tgz",
-      "integrity": "sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==",
+      "version": "22.18.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.1.tgz",
+      "integrity": "sha512-rzSDyhn4cYznVG+PCzGe1lwuMYJrcBS1fc3JqSa2PvtABwWo+dZ1ij5OVok3tqfpEBCBoaR4d7upFJk73HRJDw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/samples/nodejs/copilotstudio-skill/package-lock.json
+++ b/samples/nodejs/copilotstudio-skill/package-lock.json
@@ -55,19 +55,19 @@
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "15.11.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.11.0.tgz",
-      "integrity": "sha512-1IseGNH6XGWe+5xhZlhasTJP6Ob7tnVSlfFUnjdeH4Kik0n1SORTmdB6xxTwbx9Ro8EuO0XaRzpdABWSf15sdg==",
+      "version": "15.12.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.12.0.tgz",
+      "integrity": "sha512-4ucXbjVw8KJ5QBgnGJUeA07c8iznwlk5ioHIhI4ASXcXgcf2yRFhWzYOyWg/cI49LC9ekpFJeQtO3zjDTbl6TQ==",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.7.1.tgz",
-      "integrity": "sha512-ZTopY+BmE/OubqTXEQ5Eq+h6M5NKTchQBtvLj1tgiAf26lk2C+9jJTvtHjcyzE3iWn3wzySJLa4ArcjHJaZMQw==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.7.3.tgz",
+      "integrity": "sha512-MoJxkKM/YpChfq4g2o36tElyzNUMG8mfD6u8NbuaPAsqfGpaw249khAcJYNoIOigUzRw45OjXCOrexE6ImdUxg==",
       "dependencies": {
-        "@azure/msal-common": "15.11.0",
+        "@azure/msal-common": "15.12.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
@@ -76,17 +76,17 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
-      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@microsoft/agents-activity": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-activity/-/agents-activity-1.0.13.tgz",
-      "integrity": "sha512-G0QnQUN/QU0JBOsICRAVRSmFL7sboA2vSoFcWnL5fN5spqLcnXkNmiUhYJqSXDMZqqFWCnCq4jkcbxJD7v+w1g==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-activity/-/agents-activity-1.0.15.tgz",
+      "integrity": "sha512-1u8BVLsipsgTTte2SrR+LBXMkkU0oKteE6QDk+Dq5yTS4dF9266LPQ6HgOTNEk3PxRFSibrlw7zSO4y6S/d5wA==",
       "dependencies": {
         "debug": "^4.3.7",
         "uuid": "^11.1.0",
@@ -109,13 +109,13 @@
       }
     },
     "node_modules/@microsoft/agents-hosting": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting/-/agents-hosting-1.0.13.tgz",
-      "integrity": "sha512-pymWPGOvdZzMvtGmIZqpW7B0fgEZzquhhPJRU6g+XDvRy93S9OI5+Dwljk9xPPKJv57s/pNVeucxhcgMA67GHg==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting/-/agents-hosting-1.0.15.tgz",
+      "integrity": "sha512-f7fG0jOYH7UUmGkJT+Y7Hu4vrTrlbgsSGD18+I7H3XyrfOnAkjfwfhkd0BF6F4qCTqDokDXmcQuhlPj/w69k7w==",
       "dependencies": {
         "@azure/core-auth": "^1.10.0",
         "@azure/msal-node": "^3.7.0",
-        "@microsoft/agents-activity": "1.0.13",
+        "@microsoft/agents-activity": "1.0.15",
         "axios": "^1.11.0",
         "jsonwebtoken": "^9.0.2",
         "jwks-rsa": "^3.2.0"
@@ -214,9 +214,9 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
     "node_modules/@types/node": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
       "dependencies": {
         "undici-types": "~7.10.0"
       }
@@ -1054,11 +1054,12 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-      "engines": {
-        "node": ">=16"
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/proxy-addr": {
@@ -1101,17 +1102,32 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
+        "iconv-lite": "0.7.0",
         "unpipe": "1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/router": {

--- a/samples/nodejs/copilotstudio-webchat-react/package-lock.json
+++ b/samples/nodejs/copilotstudio-webchat-react/package-lock.json
@@ -25,22 +25,10 @@
         "node": ">=20"
       }
     },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@angular/common": {
-      "version": "20.1.7",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-20.1.7.tgz",
-      "integrity": "sha512-3eFxQ18613JpBQw53wMUZfqc2RvratWx6GqKs5A1JJpMs0qq26yc2PhJWer99u3mugpKavmKoKpXFBkuWg50Qw==",
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-20.2.4.tgz",
+      "integrity": "sha512-mc6Sq1cYjaPJYThnvG6x0f/E27pWksqwaNJxT1RtwhAGc1i2jsc0su6b7e5NnXEgVbdPqu1MZHAEFdXZ5+/MwQ==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -49,14 +37,14 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "20.1.7",
+        "@angular/core": "20.2.4",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/core": {
-      "version": "20.1.7",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.1.7.tgz",
-      "integrity": "sha512-LL5nyCQ9yrMLQMfAPgambGCPEQmpuHrg3cTRI0P9EMySgFoyyPUsIfWYYz5w1VWxmkfcXSkpNtyaNB5P60p0rg==",
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.2.4.tgz",
+      "integrity": "sha512-8yvfvPDWX8M7o82GBl5P1nlvm1ywQ2XZi5HWj3llKpSJE2XjzhATgPrpKwiNVnpgjZWTOwM11fpoAaRKqQjxTA==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -65,7 +53,7 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "20.1.7",
+        "@angular/compiler": "20.2.4",
         "rxjs": "^6.5.3 || ^7.4.0",
         "zone.js": "~0.15.0"
       },
@@ -79,20 +67,20 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.20.0.tgz",
-      "integrity": "sha512-JBGaxnYAvzFsT5TU6XhVpqc4XVMFjzsi6rrAVINX0PL3+wzs+k12fnvN/XFICvzCfV28NvHzxGfRRBoqE6GxNg==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.22.0.tgz",
+      "integrity": "sha512-JLWHzAW1aZ/L190Th56jN+2t3T1dMvXOs1obXYLEr3ZWi81vVmBCt0di3mPvTTOiWoE0Cf/4hVQ/LINilqjObA==",
       "dependencies": {
-        "@azure/msal-common": "15.11.0"
+        "@azure/msal-common": "15.12.0"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "15.11.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.11.0.tgz",
-      "integrity": "sha512-1IseGNH6XGWe+5xhZlhasTJP6Ob7tnVSlfFUnjdeH4Kik0n1SORTmdB6xxTwbx9Ro8EuO0XaRzpdABWSf15sdg==",
+      "version": "15.12.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.12.0.tgz",
+      "integrity": "sha512-4ucXbjVw8KJ5QBgnGJUeA07c8iznwlk5ioHIhI4ASXcXgcf2yRFhWzYOyWg/cI49LC9ekpFJeQtO3zjDTbl6TQ==",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -139,28 +127,28 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
-      "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
+      "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
-      "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
+      "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
         "@babel/helper-compilation-targets": "^7.27.2",
         "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.3",
-        "@babel/parser": "^7.28.3",
+        "@babel/helpers": "^7.28.4",
+        "@babel/parser": "^7.28.4",
         "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.3",
-        "@babel/types": "^7.28.2",
+        "@babel/traverse": "^7.28.4",
+        "@babel/types": "^7.28.4",
+        "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -416,23 +404,23 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.3.tgz",
-      "integrity": "sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
       "dependencies": {
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.2"
+        "@babel/types": "^7.28.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
-      "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
       "dependencies": {
-        "@babel/types": "^7.28.2"
+        "@babel/types": "^7.28.4"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -630,9 +618,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.0.tgz",
-      "integrity": "sha512-gKKnwjpdx5sER/wl0WN0efUBFzF/56YZO0RJrSYP4CljXnP31ByY7fol89AzomdlLNzI36AvOTmYHsnZTCkq8Q==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.4.tgz",
+      "integrity": "sha512-1yxmvN0MJHOhPVmAsmoW5liWwoILobu/d/ShymZmj867bAdxGbehIrew1DuLpw2Ukv+qDSSPQdYW1dLNE7t11A==",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -674,16 +662,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.3.tgz",
-      "integrity": "sha512-DoEWC5SuxuARF2KdKmGUq3ghfPMO6ZzR12Dnp5gubwbeWJo4dbNWXJPVlwvh4Zlq6Z7YVvL8VFxeSOJgjsx4Sg==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.4.tgz",
+      "integrity": "sha512-cFOlhIYPBv/iBoc+KS3M6et2XPtbT2HiCRfBXWtfpc9OAyostldxIf9YAYB6ypURBBbx+Qv6nyrLzASfJe+hBA==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
         "@babel/helper-compilation-targets": "^7.27.2",
         "@babel/helper-globals": "^7.28.0",
         "@babel/helper-plugin-utils": "^7.27.1",
         "@babel/helper-replace-supers": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/traverse": "^7.28.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1030,15 +1018,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-rest-spread": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.0.tgz",
-      "integrity": "sha512-9VNGikXxzu5eCiQjdE4IZn8sb9q7Xsk5EXLDBKUYg1e/Tve8/05+KJEtcxGxAgCY5t/BpKQM+JEL/yT4tvgiUA==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.4.tgz",
+      "integrity": "sha512-373KA2HQzKhQCYiRVIRr+3MjpCObqzDlyrM6u4I201wL8Mp2wHf7uB8GhDwis03k2ti8Zr65Zyyqs1xOxUF/Ew==",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.27.2",
         "@babel/helper-plugin-utils": "^7.27.1",
         "@babel/plugin-transform-destructuring": "^7.28.0",
         "@babel/plugin-transform-parameters": "^7.27.7",
-        "@babel/traverse": "^7.28.0"
+        "@babel/traverse": "^7.28.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1151,9 +1139,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.3.tgz",
-      "integrity": "sha512-K3/M/a4+ESb5LEldjQb+XSrpY0nF+ZBFlTCbSnKaYAMfD8v33O6PMs4uYnOk19HlcsI8WMu3McdFPTiQHF/1/A==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.4.tgz",
+      "integrity": "sha512-+ZEdQlBoRg9m2NnzvEeLgtvBMO4tkFBw5SQIUgLICgTrumLoU7lr+Oghi6km2PFj+dbUt2u1oby2w3BDO9YQnA==",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -1450,9 +1438,9 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.3.tgz",
-      "integrity": "sha512-LKYxD2CIfocUFNREQ1yk+dW+8OH8CRqmgatBZYXb+XhuObO8wsDpEoCNri5bKld9cnj8xukqZjxSX8p1YiRF8Q==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.4.tgz",
+      "integrity": "sha512-h7iEYiW4HebClDEhtvFObtPmIvrd1SSfpI9EhOeKk4CtIK/ngBWFpuhCzhdmRKtg71ylcue+9I6dv54XYO1epQ==",
       "dependencies": {
         "core-js-pure": "^3.43.0"
       },
@@ -1461,9 +1449,9 @@
       }
     },
     "node_modules/@babel/runtime-corejs3/node_modules/core-js-pure": {
-      "version": "3.45.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.45.0.tgz",
-      "integrity": "sha512-OtwjqcDpY2X/eIIg1ol/n0y/X8A9foliaNt1dSK0gV3J2/zw+89FcNG3mPK+N8YWts4ZFUPxnrAzsxs/lf8yDA==",
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.45.1.tgz",
+      "integrity": "sha512-OHnWFKgTUshEU8MK+lOs1H8kC8GkTi9Z1tvNkxrCcw9wl3MJIO7q2ld77wjWn4/xuGrVu2X+nME1iIIPBSdyEQ==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -1484,16 +1472,16 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.3.tgz",
-      "integrity": "sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
+      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.3",
+        "@babel/parser": "^7.28.4",
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.2",
+        "@babel/types": "^7.28.4",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1501,9 +1489,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
-      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1"
@@ -2031,6 +2019,15 @@
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -2054,9 +2051,9 @@
       }
     },
     "node_modules/@microsoft/agents-activity": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-activity/-/agents-activity-1.0.13.tgz",
-      "integrity": "sha512-G0QnQUN/QU0JBOsICRAVRSmFL7sboA2vSoFcWnL5fN5spqLcnXkNmiUhYJqSXDMZqqFWCnCq4jkcbxJD7v+w1g==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-activity/-/agents-activity-1.0.15.tgz",
+      "integrity": "sha512-1u8BVLsipsgTTte2SrR+LBXMkkU0oKteE6QDk+Dq5yTS4dF9266LPQ6HgOTNEk3PxRFSibrlw7zSO4y6S/d5wA==",
       "dependencies": {
         "debug": "^4.3.7",
         "uuid": "^11.1.0",
@@ -2067,11 +2064,11 @@
       }
     },
     "node_modules/@microsoft/agents-copilotstudio-client": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-copilotstudio-client/-/agents-copilotstudio-client-1.0.13.tgz",
-      "integrity": "sha512-k5nCUiEH5OvRQYHggwnAK14IkuudPdu8R9KjECVnZN98CS9lIg69klI8VgSpx8WQU45aDWkjNZ3+sRWJimZe1Q==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-copilotstudio-client/-/agents-copilotstudio-client-1.0.15.tgz",
+      "integrity": "sha512-pAMR6M5UKy7bAS9aHmsko6yuLky/7Aou6VpQ9MRCHzkKJCQEvoT57iGPip3E5H4C0EfPcW2/NkCW84+Y3hDTHw==",
       "dependencies": {
-        "@microsoft/agents-activity": "1.0.13",
+        "@microsoft/agents-activity": "1.0.15",
         "axios": "^1.9.0",
         "rxjs": "7.8.2",
         "uuid": "^11.1.0"
@@ -2099,9 +2096,9 @@
       }
     },
     "node_modules/@redux-devtools/extension/node_modules/@babel/runtime": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
-      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2951,9 +2948,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.25.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.2.tgz",
-      "integrity": "sha512-0si2SJK3ooGzIawRu61ZdPCO1IncZwS8IzuX73sPZsXW6EQ/w/DAfPyKI8l1ETTCr2MnvqWitmlCUxgdul45jA==",
+      "version": "4.25.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.4.tgz",
+      "integrity": "sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==",
       "funding": [
         {
           "type": "opencollective",
@@ -2969,8 +2966,8 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001733",
-        "electron-to-chromium": "^1.5.199",
+        "caniuse-lite": "^1.0.30001737",
+        "electron-to-chromium": "^1.5.211",
         "node-releases": "^2.0.19",
         "update-browserslist-db": "^1.1.3"
       },
@@ -3030,9 +3027,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001735",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001735.tgz",
-      "integrity": "sha512-EV/laoX7Wq2J9TQlyIXRxTJqIw4sxfXS4OYgudGxBYRuTv0q7AM6yMEpU/Vo1I94thg9U6EZ2NfZx9GJq83u7w==",
+      "version": "1.0.30001741",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
+      "integrity": "sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==",
       "funding": [
         {
           "type": "opencollective",
@@ -3177,11 +3174,11 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.45.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.45.0.tgz",
-      "integrity": "sha512-gRoVMBawZg0OnxaVv3zpqLLxaHmsubEGyTnqdpI/CEBvX4JadI1dMSHxagThprYRtSVbuQxvi6iUatdPxohHpA==",
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.45.1.tgz",
+      "integrity": "sha512-tqTt5T4PzsMIZ430XGviK4vzYSoeNJ6CXODi6c/voxOT6IZqBht5/EKaSNnYiEjjRYxjVz7DQIsOsY0XNi8PIA==",
       "dependencies": {
-        "browserslist": "^4.25.1"
+        "browserslist": "^4.25.3"
       },
       "funding": {
         "type": "opencollective",
@@ -3394,9 +3391,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.203",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.203.tgz",
-      "integrity": "sha512-uz4i0vLhfm6dLZWbz/iH88KNDV+ivj5+2SA+utpgjKaj9Q0iDLuwk6Idhe9BTxciHudyx6IvTvijhkPvFGUQ0g=="
+      "version": "1.5.215",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.215.tgz",
+      "integrity": "sha512-TIvGp57UpeNetj/wV/xpFNpWGb0b/ROw372lHPx5Aafx02gjTBtWnEEcaSX3W2dLM3OSdGGyHX/cHl01JQsLaQ=="
     },
     "node_modules/emoji-regex-xs": {
       "version": "1.0.0",
@@ -5308,9 +5305,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.20.tgz",
+      "integrity": "sha512-7gK6zSXEH6neM212JgfYFXe+GmZQM+fia5SsusuBIUgnPheLFBmIPhtFoAQRj8/7wASYQnbDlHPVwY0BefoFgA=="
     },
     "node_modules/normalize-package-data": {
       "version": "3.0.3",

--- a/samples/nodejs/langchain-multiturn/package-lock.json
+++ b/samples/nodejs/langchain-multiturn/package-lock.json
@@ -60,19 +60,19 @@
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "15.11.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.11.0.tgz",
-      "integrity": "sha512-1IseGNH6XGWe+5xhZlhasTJP6Ob7tnVSlfFUnjdeH4Kik0n1SORTmdB6xxTwbx9Ro8EuO0XaRzpdABWSf15sdg==",
+      "version": "15.12.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.12.0.tgz",
+      "integrity": "sha512-4ucXbjVw8KJ5QBgnGJUeA07c8iznwlk5ioHIhI4ASXcXgcf2yRFhWzYOyWg/cI49LC9ekpFJeQtO3zjDTbl6TQ==",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.7.1.tgz",
-      "integrity": "sha512-ZTopY+BmE/OubqTXEQ5Eq+h6M5NKTchQBtvLj1tgiAf26lk2C+9jJTvtHjcyzE3iWn3wzySJLa4ArcjHJaZMQw==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.7.3.tgz",
+      "integrity": "sha512-MoJxkKM/YpChfq4g2o36tElyzNUMG8mfD6u8NbuaPAsqfGpaw249khAcJYNoIOigUzRw45OjXCOrexE6ImdUxg==",
       "dependencies": {
-        "@azure/msal-common": "15.11.0",
+        "@azure/msal-common": "15.12.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
@@ -95,9 +95,9 @@
       "peer": true
     },
     "node_modules/@langchain/core": {
-      "version": "0.3.71",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.71.tgz",
-      "integrity": "sha512-ejArFmm/lZ9je2rbMLpkFZnva8jkvDhFCn370WAAVP8akbPOLgDA+S2e5jvj+G/oHraOwmviY8EnxbPXXcDvfw==",
+      "version": "0.3.75",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.75.tgz",
+      "integrity": "sha512-kTyBS0DTeD0JYa9YH5lg6UdDbHmvplk3t9PCjP5jDQZCK5kPe2aDFToqdiCaLzZg8RzzM+clXLVyJtPTE8bZ2Q==",
       "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
@@ -105,7 +105,7 @@
         "camelcase": "6",
         "decamelize": "1.2.0",
         "js-tiktoken": "^1.0.12",
-        "langsmith": "^0.3.46",
+        "langsmith": "^0.3.67",
         "mustache": "^4.2.0",
         "p-queue": "^6.6.2",
         "p-retry": "4",
@@ -155,9 +155,9 @@
       }
     },
     "node_modules/@langchain/langgraph-sdk": {
-      "version": "0.0.107",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-0.0.107.tgz",
-      "integrity": "sha512-2qzboDgYH8KJNz7q2Yzvj6H9i4iZUYfZnB7xY+Dkye6yvI+2m1fFIdpP/Ppu+eFvoIUAsbDHDF+wvR4F11kS3Q==",
+      "version": "0.0.112",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-0.0.112.tgz",
+      "integrity": "sha512-/9W5HSWCqYgwma6EoOspL4BGYxGxeJP6lIquPSF4FA0JlKopaUv58ucZC3vAgdJyCgg6sorCIV/qg7SGpEcCLw==",
       "dependencies": {
         "@types/json-schema": "^7.0.15",
         "p-queue": "^6.6.2",
@@ -210,9 +210,9 @@
       }
     },
     "node_modules/@microsoft/agents-activity": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-activity/-/agents-activity-1.0.13.tgz",
-      "integrity": "sha512-G0QnQUN/QU0JBOsICRAVRSmFL7sboA2vSoFcWnL5fN5spqLcnXkNmiUhYJqSXDMZqqFWCnCq4jkcbxJD7v+w1g==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-activity/-/agents-activity-1.0.15.tgz",
+      "integrity": "sha512-1u8BVLsipsgTTte2SrR+LBXMkkU0oKteE6QDk+Dq5yTS4dF9266LPQ6HgOTNEk3PxRFSibrlw7zSO4y6S/d5wA==",
       "dependencies": {
         "debug": "^4.3.7",
         "uuid": "^11.1.0",
@@ -235,13 +235,13 @@
       }
     },
     "node_modules/@microsoft/agents-hosting": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting/-/agents-hosting-1.0.13.tgz",
-      "integrity": "sha512-pymWPGOvdZzMvtGmIZqpW7B0fgEZzquhhPJRU6g+XDvRy93S9OI5+Dwljk9xPPKJv57s/pNVeucxhcgMA67GHg==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting/-/agents-hosting-1.0.15.tgz",
+      "integrity": "sha512-f7fG0jOYH7UUmGkJT+Y7Hu4vrTrlbgsSGD18+I7H3XyrfOnAkjfwfhkd0BF6F4qCTqDokDXmcQuhlPj/w69k7w==",
       "dependencies": {
         "@azure/core-auth": "^1.10.0",
         "@azure/msal-node": "^3.7.0",
-        "@microsoft/agents-activity": "1.0.13",
+        "@microsoft/agents-activity": "1.0.15",
         "axios": "^1.11.0",
         "jsonwebtoken": "^9.0.2",
         "jwks-rsa": "^3.2.0"
@@ -251,11 +251,11 @@
       }
     },
     "node_modules/@microsoft/agents-hosting-express": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting-express/-/agents-hosting-express-1.0.13.tgz",
-      "integrity": "sha512-PywQFm1RmSBEkbRuPJ6H9a94TXNyJ1MCwtpTX6Le9VJEQVFKDDBwQrmziW7vXlBbyW+nWUBDH7XkQayhsrQK3Q==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting-express/-/agents-hosting-express-1.0.15.tgz",
+      "integrity": "sha512-MyepMCp58fFEWr64fS21XDUG1rwSh5z5H90JJm25aOfbkeTvKgypVI3sP2pCo2zGW68TORC91xrvRuxYGHEoMQ==",
       "dependencies": {
-        "@microsoft/agents-hosting": "1.0.13",
+        "@microsoft/agents-hosting": "1.0.15",
         "express": "^5.1.0"
       },
       "engines": {
@@ -263,9 +263,9 @@
       }
     },
     "node_modules/@microsoft/m365agentsplayground": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/@microsoft/m365agentsplayground/-/m365agentsplayground-0.2.17.tgz",
-      "integrity": "sha512-nDcGCnvKUZ3ckI1fREgqFcFCGl7Xjlf4y9NqcgDVl6nMoV7i8SUzPZVl3Z4pCa/Qc4U4rGqlCN/YjhQzEfsHOg==",
+      "version": "0.2.18",
+      "resolved": "https://registry.npmjs.org/@microsoft/m365agentsplayground/-/m365agentsplayground-0.2.18.tgz",
+      "integrity": "sha512-8okNQ+fNQPPMBW/OSIudoCApBKqKxADNFIMivUGy/eaX9v8tFIG/gFo7DLwpaCzNuc1M8oOW9Sse1mX08Dxo0A==",
       "dev": true,
       "bin": {
         "agentsplayground": "cli.js",
@@ -341,9 +341,9 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
     "node_modules/@types/node": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
       "dependencies": {
         "undici-types": "~7.10.0"
       }
@@ -2113,9 +2113,9 @@
       }
     },
     "node_modules/langsmith": {
-      "version": "0.3.61",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.61.tgz",
-      "integrity": "sha512-b7Cpfj3xpWQO41G3xXeG6uzPzBcWfkEo5cK62WOcTqsKCchN2i42z7q45QQrbU6mdLwXp6pjRfnvr7wFu+Y5iQ==",
+      "version": "0.3.67",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.67.tgz",
+      "integrity": "sha512-l4y3RmJ9yWF5a29fLg3eWZQxn6Q6dxTOgLGgQHzPGZHF3NUynn+A+airYIe/Yt4rwjGbuVrABAPsXBkVu/Hi7g==",
       "peer": true,
       "dependencies": {
         "@types/uuid": "^10.0.0",
@@ -2548,9 +2548,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "5.12.2",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-5.12.2.tgz",
-      "integrity": "sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.20.0.tgz",
+      "integrity": "sha512-Bmc2zLM/YWgFrDpXr9hwXqGGDdMmMpE9+qoZPsaHpn0Y/Qk1Vu26hNqXo7+nHdli+sLsXINvS1f8kR3NKhGKmA==",
       "bin": {
         "openai": "bin/cli"
       },
@@ -2667,11 +2667,12 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-      "engines": {
-        "node": ">=16"
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/path-type": {
@@ -2774,17 +2775,32 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
+        "iconv-lite": "0.7.0",
         "unpipe": "1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/read-pkg": {

--- a/samples/nodejs/multi-turn-prompt/package-lock.json
+++ b/samples/nodejs/multi-turn-prompt/package-lock.json
@@ -58,19 +58,19 @@
             }
         },
         "node_modules/@azure/msal-common": {
-            "version": "15.11.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.11.0.tgz",
-            "integrity": "sha512-1IseGNH6XGWe+5xhZlhasTJP6Ob7tnVSlfFUnjdeH4Kik0n1SORTmdB6xxTwbx9Ro8EuO0XaRzpdABWSf15sdg==",
+            "version": "15.12.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.12.0.tgz",
+            "integrity": "sha512-4ucXbjVw8KJ5QBgnGJUeA07c8iznwlk5ioHIhI4ASXcXgcf2yRFhWzYOyWg/cI49LC9ekpFJeQtO3zjDTbl6TQ==",
             "engines": {
                 "node": ">=0.8.0"
             }
         },
         "node_modules/@azure/msal-node": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.7.1.tgz",
-            "integrity": "sha512-ZTopY+BmE/OubqTXEQ5Eq+h6M5NKTchQBtvLj1tgiAf26lk2C+9jJTvtHjcyzE3iWn3wzySJLa4ArcjHJaZMQw==",
+            "version": "3.7.3",
+            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.7.3.tgz",
+            "integrity": "sha512-MoJxkKM/YpChfq4g2o36tElyzNUMG8mfD6u8NbuaPAsqfGpaw249khAcJYNoIOigUzRw45OjXCOrexE6ImdUxg==",
             "dependencies": {
-                "@azure/msal-common": "15.11.0",
+                "@azure/msal-common": "15.12.0",
                 "jsonwebtoken": "^9.0.0",
                 "uuid": "^8.3.0"
             },
@@ -495,9 +495,9 @@
             }
         },
         "node_modules/@microsoft/agents-activity": {
-            "version": "1.0.13",
-            "resolved": "https://registry.npmjs.org/@microsoft/agents-activity/-/agents-activity-1.0.13.tgz",
-            "integrity": "sha512-G0QnQUN/QU0JBOsICRAVRSmFL7sboA2vSoFcWnL5fN5spqLcnXkNmiUhYJqSXDMZqqFWCnCq4jkcbxJD7v+w1g==",
+            "version": "1.0.15",
+            "resolved": "https://registry.npmjs.org/@microsoft/agents-activity/-/agents-activity-1.0.15.tgz",
+            "integrity": "sha512-1u8BVLsipsgTTte2SrR+LBXMkkU0oKteE6QDk+Dq5yTS4dF9266LPQ6HgOTNEk3PxRFSibrlw7zSO4y6S/d5wA==",
             "dependencies": {
                 "debug": "^4.3.7",
                 "uuid": "^11.1.0",
@@ -520,13 +520,13 @@
             }
         },
         "node_modules/@microsoft/agents-hosting": {
-            "version": "1.0.13",
-            "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting/-/agents-hosting-1.0.13.tgz",
-            "integrity": "sha512-pymWPGOvdZzMvtGmIZqpW7B0fgEZzquhhPJRU6g+XDvRy93S9OI5+Dwljk9xPPKJv57s/pNVeucxhcgMA67GHg==",
+            "version": "1.0.15",
+            "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting/-/agents-hosting-1.0.15.tgz",
+            "integrity": "sha512-f7fG0jOYH7UUmGkJT+Y7Hu4vrTrlbgsSGD18+I7H3XyrfOnAkjfwfhkd0BF6F4qCTqDokDXmcQuhlPj/w69k7w==",
             "dependencies": {
                 "@azure/core-auth": "^1.10.0",
                 "@azure/msal-node": "^3.7.0",
-                "@microsoft/agents-activity": "1.0.13",
+                "@microsoft/agents-activity": "1.0.15",
                 "axios": "^1.11.0",
                 "jsonwebtoken": "^9.0.2",
                 "jwks-rsa": "^3.2.0"
@@ -536,11 +536,11 @@
             }
         },
         "node_modules/@microsoft/agents-hosting-dialogs": {
-            "version": "1.0.13",
-            "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting-dialogs/-/agents-hosting-dialogs-1.0.13.tgz",
-            "integrity": "sha512-LyQUWtFO+kMmZyCInpL5Py3obSQxkrrrPq9S12+kMw3GGi7NVRXUdfLmB6pc0a4KsH/VrjUiGxHFE38w45opVQ==",
+            "version": "1.0.15",
+            "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting-dialogs/-/agents-hosting-dialogs-1.0.15.tgz",
+            "integrity": "sha512-L292K21Y+GoBYHOagDGRBAtQVo5DM1Yq7n8qP3GMrBFGqT9YuM6Qad4skyJE8sr50OspV9yzQVOg0ZvXFTBXWQ==",
             "dependencies": {
-                "@microsoft/agents-hosting": "1.0.13",
+                "@microsoft/agents-hosting": "1.0.15",
                 "@microsoft/recognizers-text-choice": "^1.3.1",
                 "@microsoft/recognizers-text-date-time": "^1.3.2",
                 "@microsoft/recognizers-text-number": "^1.3.1",
@@ -554,9 +554,9 @@
             }
         },
         "node_modules/@microsoft/m365agentsplayground": {
-            "version": "0.2.17",
-            "resolved": "https://registry.npmjs.org/@microsoft/m365agentsplayground/-/m365agentsplayground-0.2.17.tgz",
-            "integrity": "sha512-nDcGCnvKUZ3ckI1fREgqFcFCGl7Xjlf4y9NqcgDVl6nMoV7i8SUzPZVl3Z4pCa/Qc4U4rGqlCN/YjhQzEfsHOg==",
+            "version": "0.2.18",
+            "resolved": "https://registry.npmjs.org/@microsoft/m365agentsplayground/-/m365agentsplayground-0.2.18.tgz",
+            "integrity": "sha512-8okNQ+fNQPPMBW/OSIudoCApBKqKxADNFIMivUGy/eaX9v8tFIG/gFo7DLwpaCzNuc1M8oOW9Sse1mX08Dxo0A==",
             "dev": true,
             "bin": {
                 "agentsplayground": "cli.js",
@@ -729,9 +729,9 @@
             "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
         },
         "node_modules/@types/node": {
-            "version": "22.17.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.2.tgz",
-            "integrity": "sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==",
+            "version": "22.18.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.1.tgz",
+            "integrity": "sha512-rzSDyhn4cYznVG+PCzGe1lwuMYJrcBS1fc3JqSa2PvtABwWo+dZ1ij5OVok3tqfpEBCBoaR4d7upFJk73HRJDw==",
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
@@ -2665,11 +2665,12 @@
             "dev": true
         },
         "node_modules/path-to-regexp": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-            "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-            "engines": {
-                "node": ">=16"
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+            "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/path-type": {
@@ -2754,17 +2755,32 @@
             }
         },
         "node_modules/raw-body": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-            "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+            "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
             "dependencies": {
                 "bytes": "3.1.2",
                 "http-errors": "2.0.0",
-                "iconv-lite": "0.6.3",
+                "iconv-lite": "0.7.0",
                 "unpipe": "1.0.0"
             },
             "engines": {
-                "node": ">= 0.8"
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/raw-body/node_modules/iconv-lite": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+            "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/read-pkg": {

--- a/samples/nodejs/obo-authorization/package-lock.json
+++ b/samples/nodejs/obo-authorization/package-lock.json
@@ -54,19 +54,19 @@
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "15.11.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.11.0.tgz",
-      "integrity": "sha512-1IseGNH6XGWe+5xhZlhasTJP6Ob7tnVSlfFUnjdeH4Kik0n1SORTmdB6xxTwbx9Ro8EuO0XaRzpdABWSf15sdg==",
+      "version": "15.12.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.12.0.tgz",
+      "integrity": "sha512-4ucXbjVw8KJ5QBgnGJUeA07c8iznwlk5ioHIhI4ASXcXgcf2yRFhWzYOyWg/cI49LC9ekpFJeQtO3zjDTbl6TQ==",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.7.1.tgz",
-      "integrity": "sha512-ZTopY+BmE/OubqTXEQ5Eq+h6M5NKTchQBtvLj1tgiAf26lk2C+9jJTvtHjcyzE3iWn3wzySJLa4ArcjHJaZMQw==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.7.3.tgz",
+      "integrity": "sha512-MoJxkKM/YpChfq4g2o36tElyzNUMG8mfD6u8NbuaPAsqfGpaw249khAcJYNoIOigUzRw45OjXCOrexE6ImdUxg==",
       "dependencies": {
-        "@azure/msal-common": "15.11.0",
+        "@azure/msal-common": "15.12.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
@@ -75,9 +75,9 @@
       }
     },
     "node_modules/@microsoft/agents-activity": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-activity/-/agents-activity-1.0.13.tgz",
-      "integrity": "sha512-G0QnQUN/QU0JBOsICRAVRSmFL7sboA2vSoFcWnL5fN5spqLcnXkNmiUhYJqSXDMZqqFWCnCq4jkcbxJD7v+w1g==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-activity/-/agents-activity-1.0.15.tgz",
+      "integrity": "sha512-1u8BVLsipsgTTte2SrR+LBXMkkU0oKteE6QDk+Dq5yTS4dF9266LPQ6HgOTNEk3PxRFSibrlw7zSO4y6S/d5wA==",
       "dependencies": {
         "debug": "^4.3.7",
         "uuid": "^11.1.0",
@@ -100,13 +100,13 @@
       }
     },
     "node_modules/@microsoft/agents-hosting": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting/-/agents-hosting-1.0.13.tgz",
-      "integrity": "sha512-pymWPGOvdZzMvtGmIZqpW7B0fgEZzquhhPJRU6g+XDvRy93S9OI5+Dwljk9xPPKJv57s/pNVeucxhcgMA67GHg==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting/-/agents-hosting-1.0.15.tgz",
+      "integrity": "sha512-f7fG0jOYH7UUmGkJT+Y7Hu4vrTrlbgsSGD18+I7H3XyrfOnAkjfwfhkd0BF6F4qCTqDokDXmcQuhlPj/w69k7w==",
       "dependencies": {
         "@azure/core-auth": "^1.10.0",
         "@azure/msal-node": "^3.7.0",
-        "@microsoft/agents-activity": "1.0.13",
+        "@microsoft/agents-activity": "1.0.15",
         "axios": "^1.11.0",
         "jsonwebtoken": "^9.0.2",
         "jwks-rsa": "^3.2.0"
@@ -116,11 +116,11 @@
       }
     },
     "node_modules/@microsoft/agents-hosting-express": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting-express/-/agents-hosting-express-1.0.13.tgz",
-      "integrity": "sha512-PywQFm1RmSBEkbRuPJ6H9a94TXNyJ1MCwtpTX6Le9VJEQVFKDDBwQrmziW7vXlBbyW+nWUBDH7XkQayhsrQK3Q==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting-express/-/agents-hosting-express-1.0.15.tgz",
+      "integrity": "sha512-MyepMCp58fFEWr64fS21XDUG1rwSh5z5H90JJm25aOfbkeTvKgypVI3sP2pCo2zGW68TORC91xrvRuxYGHEoMQ==",
       "dependencies": {
-        "@microsoft/agents-hosting": "1.0.13",
+        "@microsoft/agents-hosting": "1.0.15",
         "express": "^5.1.0"
       },
       "engines": {
@@ -197,9 +197,9 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
     "node_modules/@types/node": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
       "dependencies": {
         "undici-types": "~7.10.0"
       }
@@ -1025,11 +1025,12 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-      "engines": {
-        "node": ">=16"
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/proxy-addr": {
@@ -1072,17 +1073,32 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
+        "iconv-lite": "0.7.0",
         "unpipe": "1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/router": {

--- a/samples/nodejs/quickstart/package-lock.json
+++ b/samples/nodejs/quickstart/package-lock.json
@@ -57,19 +57,19 @@
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "15.11.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.11.0.tgz",
-      "integrity": "sha512-1IseGNH6XGWe+5xhZlhasTJP6Ob7tnVSlfFUnjdeH4Kik0n1SORTmdB6xxTwbx9Ro8EuO0XaRzpdABWSf15sdg==",
+      "version": "15.12.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.12.0.tgz",
+      "integrity": "sha512-4ucXbjVw8KJ5QBgnGJUeA07c8iznwlk5ioHIhI4ASXcXgcf2yRFhWzYOyWg/cI49LC9ekpFJeQtO3zjDTbl6TQ==",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.7.1.tgz",
-      "integrity": "sha512-ZTopY+BmE/OubqTXEQ5Eq+h6M5NKTchQBtvLj1tgiAf26lk2C+9jJTvtHjcyzE3iWn3wzySJLa4ArcjHJaZMQw==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.7.3.tgz",
+      "integrity": "sha512-MoJxkKM/YpChfq4g2o36tElyzNUMG8mfD6u8NbuaPAsqfGpaw249khAcJYNoIOigUzRw45OjXCOrexE6ImdUxg==",
       "dependencies": {
-        "@azure/msal-common": "15.11.0",
+        "@azure/msal-common": "15.12.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
@@ -78,9 +78,9 @@
       }
     },
     "node_modules/@microsoft/agents-activity": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-activity/-/agents-activity-1.0.13.tgz",
-      "integrity": "sha512-G0QnQUN/QU0JBOsICRAVRSmFL7sboA2vSoFcWnL5fN5spqLcnXkNmiUhYJqSXDMZqqFWCnCq4jkcbxJD7v+w1g==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-activity/-/agents-activity-1.0.15.tgz",
+      "integrity": "sha512-1u8BVLsipsgTTte2SrR+LBXMkkU0oKteE6QDk+Dq5yTS4dF9266LPQ6HgOTNEk3PxRFSibrlw7zSO4y6S/d5wA==",
       "dependencies": {
         "debug": "^4.3.7",
         "uuid": "^11.1.0",
@@ -103,13 +103,13 @@
       }
     },
     "node_modules/@microsoft/agents-hosting": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting/-/agents-hosting-1.0.13.tgz",
-      "integrity": "sha512-pymWPGOvdZzMvtGmIZqpW7B0fgEZzquhhPJRU6g+XDvRy93S9OI5+Dwljk9xPPKJv57s/pNVeucxhcgMA67GHg==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting/-/agents-hosting-1.0.15.tgz",
+      "integrity": "sha512-f7fG0jOYH7UUmGkJT+Y7Hu4vrTrlbgsSGD18+I7H3XyrfOnAkjfwfhkd0BF6F4qCTqDokDXmcQuhlPj/w69k7w==",
       "dependencies": {
         "@azure/core-auth": "^1.10.0",
         "@azure/msal-node": "^3.7.0",
-        "@microsoft/agents-activity": "1.0.13",
+        "@microsoft/agents-activity": "1.0.15",
         "axios": "^1.11.0",
         "jsonwebtoken": "^9.0.2",
         "jwks-rsa": "^3.2.0"
@@ -119,9 +119,9 @@
       }
     },
     "node_modules/@microsoft/m365agentsplayground": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/@microsoft/m365agentsplayground/-/m365agentsplayground-0.2.17.tgz",
-      "integrity": "sha512-nDcGCnvKUZ3ckI1fREgqFcFCGl7Xjlf4y9NqcgDVl6nMoV7i8SUzPZVl3Z4pCa/Qc4U4rGqlCN/YjhQzEfsHOg==",
+      "version": "0.2.18",
+      "resolved": "https://registry.npmjs.org/@microsoft/m365agentsplayground/-/m365agentsplayground-0.2.18.tgz",
+      "integrity": "sha512-8okNQ+fNQPPMBW/OSIudoCApBKqKxADNFIMivUGy/eaX9v8tFIG/gFo7DLwpaCzNuc1M8oOW9Sse1mX08Dxo0A==",
       "dev": true,
       "bin": {
         "agentsplayground": "cli.js",
@@ -192,9 +192,9 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
     "node_modules/@types/node": {
-      "version": "22.17.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.2.tgz",
-      "integrity": "sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==",
+      "version": "22.18.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.1.tgz",
+      "integrity": "sha512-rzSDyhn4cYznVG+PCzGe1lwuMYJrcBS1fc3JqSa2PvtABwWo+dZ1ij5OVok3tqfpEBCBoaR4d7upFJk73HRJDw==",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2048,11 +2048,12 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-      "engines": {
-        "node": ">=16"
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/path-type": {
@@ -2137,17 +2138,32 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
+        "iconv-lite": "0.7.0",
         "unpipe": "1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/read-pkg": {


### PR DESCRIPTION
- Bump @azure/msal-common from 15.11.0 to 15.12.0
- Bump @azure/msal-node from 3.7.1 to 3.7.3
- Bump @microsoft/agents-activity from 1.0.13 to 1.0.15
- Bump @microsoft/agents-hosting from 1.0.13 to 1.0.15
- Bump @microsoft/agents-hosting-express from 1.0.13 to 1.0.15
- Bump @microsoft/agents-hosting-dialogs from 1.0.13 to 1.0.15
- Bump @microsoft/m365agentsplayground from 0.2.17 to 0.2.18
- Bump @types/node from 22.17.2 to 22.18.1
- Bump path-to-regexp from 8.2.0 to 8.3.0
- Bump raw-body from 3.0.0 to 3.0.1
- Update iconv-lite dependency to 0.7.0