### PR TITLE
Refactor agent.py: remove redundant comments

### DIFF
--- a/samples/python/quickstart/src/agent.py
+++ b/samples/python/quickstart/src/agent.py
@@ -19,7 +19,7 @@ from microsoft_agents.hosting.core import (
 from microsoft_agents.authentication.msal import MsalConnectionManager
 from microsoft_agents.activity import load_configuration_from_env
 
-load_dotenv()  # robrandao: todo
+load_dotenv()
 agents_sdk_config = load_configuration_from_env(environ)
 
 STORAGE = MemoryStorage()
@@ -27,7 +27,7 @@ CONNECTION_MANAGER = MsalConnectionManager(**agents_sdk_config)
 ADAPTER = CloudAdapter(connection_manager=CONNECTION_MANAGER)
 AUTHORIZATION = Authorization(STORAGE, CONNECTION_MANAGER, **agents_sdk_config)
 
-# robrandao: downloader?
+
 AGENT_APP = AgentApplication[TurnState](
     storage=STORAGE, adapter=ADAPTER, authorization=AUTHORIZATION, **agents_sdk_config
 )


### PR DESCRIPTION
Removes comments that are not indicative of what the code is doing.

`# robrandao: todo`

`# robrandao: downloader?`