### PR TITLE
Update contributing section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Your use of other services in connection with the Microsoft 365 Agents SDK is go
 
 ## Contributing
 
+#### Note for Microsoft intenral developers: 
+- Internal Micrsoft Developers should join the Core identity group [Agents SDK Contrib](https://coreidentity.microsoft.com/manage/Entitlement/entitlement/agentssdkint-upyj)
+
+#### Non-Microsoft internal developers:
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
 the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.


### PR DESCRIPTION
This pull request updates the `README.md` to clarify the contribution process for both Microsoft internal developers and external contributors. The main addition is a note specifically for Microsoft internal developers, directing them to join the appropriate Core Identity group.

Contribution guidelines update:

* Added a section for Microsoft internal developers with instructions to join the Core Identity group `Agents SDK Contrib` via a provided link.
* Clarified the distinction between internal and external contributors in the contribution guidelines.Added notes for Microsoft internal and non-internal developers regarding contributions.