### PR TITLE
Reverted inadvertant change to per-route + AutoSignin in OBOAuthorization

### DIFF
--- a/samples/dotnet/GenesysHandoff/GenesysHandoffAgent.cs
+++ b/samples/dotnet/GenesysHandoff/GenesysHandoffAgent.cs
@@ -38,7 +38,7 @@ namespace GenesysHandoff
             _genesysService = genesysService;
             OnMessage("-reset", HandleResetMessage);
             OnMessage("-signout", HandleSignOut);
-            OnActivity((turnContext, cancellationToken) => Task.FromResult(true), HandleAllActivities, autoSignInHandlers: ["mcs"]);
+            OnActivity((turnContext, cancellationToken) => Task.FromResult(true), HandleAllActivities);
             UserAuthorization.OnUserSignInFailure(async (turnContext, turnState, handlerName, response, initiatingActivity, cancellationToken) =>
             {
                 await turnContext.SendActivityAsync($"SignIn failed with '{handlerName}': {response.Cause}/{response.Error!.Message}", cancellationToken: cancellationToken);

--- a/samples/dotnet/GenesysHandoff/appManifest/manifest.json
+++ b/samples/dotnet/GenesysHandoff/appManifest/manifest.json
@@ -14,12 +14,12 @@
     "outline": "outline.png"
   },
   "name": {
-    "short": "User Authorization (OAuth+OBO)",
-    "full": "User Authorization (OAuth+OBO)"
+    "short": "GenesysHandoffAgent",
+    "full": "GenesysHandoffAgent"
   },
   "description": {
-    "short": "Sample demonstrating Azure Bot Services user authorization with using a Agent.",
-    "full": "This sample demonstrates how to integrate with Microsoft Copilot Studio using OBO and CopilotStudioClient."
+    "short": "Genesys Handoff",
+    "full": "Integrating Genesys Handoff functionality within a Microsoft Copilot Studio agent."
   },
   "accentColor": "#FFFFFF",
   "copilotAgents": {

--- a/samples/dotnet/GenesysHandoff/appsettings.json
+++ b/samples/dotnet/GenesysHandoff/appsettings.json
@@ -1,6 +1,6 @@
 {
   "TokenValidation": {
-    "Enabled": true,
+    "Enabled": false,
     "Audiences": [
       "{{ClientID}}"
     ],

--- a/samples/dotnet/obo-authorization/Program.cs
+++ b/samples/dotnet/obo-authorization/Program.cs
@@ -67,11 +67,9 @@ builder.AddAgent(sp =>
 
     // Since Auto SignIn is enabled, by the time this is called the token is already available via UserAuthorization.GetTurnTokenAsync or
     // UserAuthorization.ExchangeTurnTokenAsync.
-    // NOTE:  This is a slightly unusual way to handle incoming Activities (but perfectly) valid.  For this sample,
-    // we just want to proxy messages to/from a Copilot Studio Agent.
+    // For this sample we just want to proxy messages to a Copilot Studio Agent.
     app.OnActivity((turnContext, cancellationToken) => Task.FromResult(true), async (turnContext, turnState, cancellationToken) =>
     {
-        
         var mcsConversationId = turnState.Conversation.GetValue<string>(MCSConversationPropertyName);
         var cpsClient = GetClient(app, turnContext);
 
@@ -100,7 +98,7 @@ builder.AddAgent(sp =>
                 }
             }
         }
-    }, autoSignInHandlers: ["mcs"]);
+    });
 
     // Called when the OAuth flow fails
     app.UserAuthorization.OnUserSignInFailure(async (turnContext, turnState, handlerName, response, initiatingActivity, cancellationToken) =>

--- a/samples/dotnet/obo-authorization/appsettings.json
+++ b/samples/dotnet/obo-authorization/appsettings.json
@@ -14,6 +14,7 @@
 
     "UserAuthorization": {
       "AutoSignIn": true,
+      "DefaultHandlerName": "mcs",
       "Handlers": {
         "mcs": {
           "Settings": {


### PR DESCRIPTION
- Correct inadvertent change to use both AutoSignin and Per-Route in the DotNet OBOAuthorization sample.  Resulting it some duplication.
- Corrected the GenysisHandoffAgent for the same since it was probably copied from the OBO sample.