### PR TITLE
Extend Activity Schema to Support Multimodal Interactions with Streaming

### DIFF
--- a/specs/activity/protocol-activity.md
+++ b/specs/activity/protocol-activity.md
@@ -2443,9 +2443,7 @@ server  → event:  Voice.Message
 > **Notes:** 
 > - `listening` is NOT needed as a separate step if included in the `session.init` commandResult.
 > - `thinking` and `speaking` session.update messages are optional and threshold-based.
-> - Media streaming events are fire-and-forget (no acknowledgment required). 
-> - `listening` is NOT needed as a separate step if included in the `session.init` commandResult.
-> - `thinking` and `speaking` session.update messages are optional and threshold-based.
+> - Media streaming events are fire-and-forget (no acknowledgment required).
 
 `A9440`: Session lifecycle commands follow request/response semantics; receivers SHOULD send acknowledgments via `commandResult`.
 


### PR DESCRIPTION
This PR implements the approved proposal from issue #416 to extend the Activity Protocol schema for multimodal interactions with streaming support for voice/audio.

Changes:
- Added Reserved Events for Media Streaming (Media.Start, Media.Chunk, Media.End, Voice.Message)
- Extended streaminfo entity to support media streaming with streamState property
- Added Session Lifecycle Commands (session.init, session.update, session.end) for multimodal interactions
- Bumped version to Provisional 3.4

Key design decisions (per AP Core Committee):
- No new activity types - uses existing event, command, commandResult
- No new schema fields - uses existing value, valueType, entities
- 100% backward compatible
- Uses streamInfo entity for stream metadata and sequencing
- Uses Media.* prefix for media streaming events

Related: #416