### PR TITLE
Add Bicep files for Azure Bot Agent SSO configuration and update docu…

### DIFF
--- a/agent-plugins/agents-for-js/skills/azure-agents-sdk-provision/Create_SSO_AppRegistration.bicep
+++ b/agent-plugins/agents-for-js/skills/azure-agents-sdk-provision/Create_SSO_AppRegistration.bicep
@@ -1,0 +1,110 @@
+// =============================================================================
+// Create_SSO_AppRegistration.bicep
+// Phase 1 — Creates the base Entra ID App Registration for an Azure Bot Agent with SSO configuration for basic graph authentication 
+// with Teams SSO support.
+//
+//
+// Requirements:
+//   - Bicep CLI 0.26.0+
+//   - Microsoft Graph Bicep extension enabled
+//
+// Output example:
+//   newAppId: The appId of the newly created App Registration
+//   newAppObjectId: The objectId of the newly created App Registration
+// =============================================================================
+
+extension microsoftGraph
+
+// -------------------------------------------------------
+// Parameters
+// -------------------------------------------------------
+// NAME OF THE APP REGISTRATION
+param APP_NAME string
+// OBJECT ID OF THE OWNER OF THE APP REGISTRATION, THIS SHOULD BE THE CREATING USER'S OBJECT ID
+param OWNER_OBJECT_ID string
+// GENERATED OAUTH SCOPE ID FOR PRE-AUTHORIZATION (GUID FORMAT)
+param OAUTH_SCOPE_ID string
+// REDIRECT URI FOR THE AZURE BOT SERVICE (defaulted for all commerical regions)
+param ABS_REDIRECTURI string = 'https://token.botframework.com/.auth/web/redirect'
+
+// -------------------------------------------------------
+// App Registration
+// -------------------------------------------------------
+resource botApp 'Microsoft.Graph/applications@v1.0' = {
+  // uniqueName makes this resource idempotent and referenceable in Phase 2
+  uniqueName: APP_NAME
+  displayName: APP_NAME
+  signInAudience: 'AzureADMyOrg'
+
+  // identifierUris intentionally empty at creation — set in Phase 2
+  identifierUris: []
+
+  web: {
+    redirectUris: [
+      ABS_REDIRECTURI
+    ]
+    implicitGrantSettings: {
+      enableAccessTokenIssuance: false
+      enableIdTokenIssuance: false
+    }
+  }
+
+  owners: {
+    relationships: [
+      OWNER_OBJECT_ID
+    ]
+  }
+
+  // Microsoft Graph delegated permissions to support user login, Additional permissions can be added as needed to support other Graph API calls
+  requiredResourceAccess: [
+    {
+      resourceAppId: '00000003-0000-0000-c000-000000000000' // Microsoft Graph
+      resourceAccess: [
+        { id: 'e1fe6dd8-ba31-4d61-89e7-88639da4683d', type: 'Scope' } // User.Read
+        { id: '37f7f235-527c-4136-accd-4a02d197296e', type: 'Scope' } // openid
+        { id: '14dad69e-099b-42c9-810b-d002981feec1', type: 'Scope' } // profile
+      ]
+    }
+  ]
+}
+
+// -------------------------------------------------------
+// Update App Registration with API configuration for Bot Framework / Teams SSO
+// This will update the App Registration with the required API configuration for Bot Framework / Teams SSO
+// -------------------------------------------------------
+
+resource botAppUp1 'Microsoft.Graph/applications@v1.0' = {
+  uniqueName: APP_NAME
+  displayName: APP_NAME
+
+  // api://botid-{appId} is required for Bot Framework / Teams SSO
+  identifierUris: [
+    'api://botid-${botApp.appId}'
+  ]
+
+  api: {
+    // Re-specify scope to preserve it during the in-place update
+    oauth2PermissionScopes: [
+      {
+        id: OAUTH_SCOPE_ID
+        adminConsentDescription: 'Allow the app to access the agent on behalf of the signed-in user.'
+        adminConsentDisplayName: 'Access the agent as a user'
+        isEnabled: true
+        type: 'User'
+        userConsentDescription: 'Allow this app to access the agent on your behalf.'
+        userConsentDisplayName: 'Access the agent as a user'
+        value: 'access_as_user'
+      }
+    ]
+  }
+}
+
+// -------------------------------------------------------
+// Outputs
+// -------------------------------------------------------
+output newAppId string = botApp.appId
+output newAppObjectId string = botApp.id
+
+
+
+

--- a/agent-plugins/agents-for-js/skills/azure-agents-sdk-provision/Create_SSO_PreAuthorize.bicep
+++ b/agent-plugins/agents-for-js/skills/azure-agents-sdk-provision/Create_SSO_PreAuthorize.bicep
@@ -1,0 +1,52 @@
+// =============================================================================
+// Create_SSO_PreAuthorize.bicep
+// Phase 2 — Updates the base Entra ID App Registration to add Preauthorized Applications to the API configuration to support Teams SSO
+//
+// Requirements:
+//   - Bicep CLI 0.26.0+
+//   - Microsoft Graph Bicep extension enabled
+//
+// =============================================================================
+
+extension microsoftGraph
+
+// -------------------------------------------------------
+// Parameters
+// -------------------------------------------------------
+// NAME OF THE APP REGISTRATION
+param APP_NAME string
+// GENERATED OAUTH SCOPE ID FOR PRE-AUTHORIZATION (GUID FORMAT)
+param OAUTH_SCOPE_ID string
+
+// -------------------------------------------------------
+// Update App Registration with Preauthorized Applications for Teams SSO
+// -------------------------------------------------------
+resource botAppUp3 'Microsoft.Graph/applications@v1.0' = {
+  uniqueName: APP_NAME
+  displayName: APP_NAME
+
+  api: {
+    // Pre-authorized Microsoft first-party Teams/Office clients
+    preAuthorizedApplications: [
+      // Microsoft Teams (web)
+      { appId: '4345a7b9-9a63-4910-a426-35363201d503', delegatedPermissionIds: [OAUTH_SCOPE_ID] }
+      // Office 365 / Outlook Online
+      { appId: '00000002-0000-0ff1-ce00-000000000000', delegatedPermissionIds: [OAUTH_SCOPE_ID] }
+      // Microsoft Teams (mobile/desktop)
+      { appId: '27922004-5251-4030-b22d-91ecd9a37ea4', delegatedPermissionIds: [OAUTH_SCOPE_ID] }
+      // Microsoft 365 web
+      { appId: '4765445b-32c6-49b0-83e6-1d93765276ca', delegatedPermissionIds: [OAUTH_SCOPE_ID] }
+      // Office UWP / PWA
+      { appId: '0ec893e0-5785-4de6-99da-4ed124e5296c', delegatedPermissionIds: [OAUTH_SCOPE_ID] }
+      // Teams web app
+      { appId: 'bc59ab01-8403-45c6-8796-ac3ef710b3e3', delegatedPermissionIds: [OAUTH_SCOPE_ID] }
+      // Microsoft Office (desktop)
+      { appId: 'd3590ed6-52b3-4102-aeff-aad2292ab01c', delegatedPermissionIds: [OAUTH_SCOPE_ID] }
+      // Teams mobile client
+      { appId: '5e3ce6c0-2b1f-4285-8d4b-75ee78787346', delegatedPermissionIds: [OAUTH_SCOPE_ID] }
+      // Teams mobile app
+      { appId: '1fec8e78-bce4-4aaf-ab1b-5451cc387264', delegatedPermissionIds: [OAUTH_SCOPE_ID] }
+    ]
+  }
+}
+

--- a/agent-plugins/agents-for-js/skills/azure-agents-sdk-provision/ProvisionABS.bicep
+++ b/agent-plugins/agents-for-js/skills/azure-agents-sdk-provision/ProvisionABS.bicep
@@ -1,0 +1,37 @@
+param BOT_NAME string = 'MattBBot01'
+param BOT_DEPLOYMENT_TYPE string = 'SingleTenant'
+param APP_ID string = '982f1994-71b1-4cea-be76-77e0649f7b16'
+param TENANT_ID string = '367c5af9-6300-4248-99bc-72288021c775'
+param DEPLOYMENT_AZURE_REGION string = 'global'
+
+resource botService 'Microsoft.BotService/botServices@2023-09-15-preview' = {
+  name: BOT_NAME
+  location: DEPLOYMENT_AZURE_REGION
+  sku: {
+    name: 'S1'
+  }
+  kind: 'azurebot'
+  properties: {
+    endpoint: ''
+    displayName: BOT_NAME
+    msaAppType: BOT_DEPLOYMENT_TYPE
+    msaAppId: APP_ID
+    msaAppTenantId: TENANT_ID
+    isStreamingSupported: false
+    schemaTransformationVersion: '1.3'
+    tenantId: TENANT_ID
+  }
+}
+
+resource symbolicname 'Microsoft.BotService/botServices/channels@2023-09-15-preview' = {
+  parent: botService
+  name: 'MsTeamsChannel'
+  location: DEPLOYMENT_AZURE_REGION
+  properties: {
+    channelName: 'MsTeamsChannel'
+    properties: {
+      acceptedTerms: true
+      isEnabled: true
+    }
+  }
+}

--- a/agent-plugins/agents-for-js/skills/azure-agents-sdk-provision/SKILL.md
+++ b/agent-plugins/agents-for-js/skills/azure-agents-sdk-provision/SKILL.md
@@ -66,13 +66,14 @@ The bot has an App Registration (for a stable `clientId` and tenant-scoped ident
 The bot has an App Registration with a generated client secret. The secret is stored in config and sent to Azure AD to obtain tokens. Classic service principal authentication.
 
 **Use when:** The bot runs outside Azure (local dev, on-prem, other cloud), the JS SDK is in use, or you need the quickest path to a working bot without MSI infrastructure.
+**How to execute:**  Use Option C in Step 1 below, which runs two Bicep deployments to create the app registration with Teams SSO support, then generates a client secret.
 
 **Implies:**
 - A secret exists and must be protected — store in Key Vault, GitHub Secrets, or environment secret manager; **never in source control**
 - Secrets expire (default 1–2 years) and must be rotated before expiry, or the bot stops authenticating
 - Widest attack surface: a leaked secret allows anyone to authenticate as the bot from anywhere
 - Easiest to use in CI/CD and local dev (just set env vars)
-- `az ad app credential reset` generates a new secret and immediately invalidates the old one — coordinate rotation carefully
+- `az ad app credential reset --append` adds a new secret without invalidating existing ones — always use `--append`, then remove the old secret key ID after deploying
 
 **Not suitable for:** High-security production environments where secret management overhead is unacceptable.
 
@@ -158,41 +159,200 @@ Config output:
 
 ### Option C: ClientSecret
 
+Uses two Bicep deployments to create a Teams SSO-capable app registration, then generates a client secret.
+
+**Prerequisites:** Bicep CLI 0.26.0+ (`az bicep install`) with the Microsoft Graph Bicep extension. Account requires Application Administrator or Global Administrator role.
+
+**Step 0 — Verify active tenant matches the intended tenant:**
+
+Run this before collecting any other inputs. If the user specified a tenant domain (e.g. `asdkt3.onmicrosoft.com`), confirm it matches before proceeding.
+
 ```bash
-# 1. Create app registration
-APP=$(az ad app create \
-  --display-name "$BOT_NAME" \
-  --sign-in-audience "AzureADMyOrg" --output json)
-APP_ID=$(echo $APP | jq -r '.appId')
-
-# 2. Generate client secret (save the password — it won't be shown again)
-SECRET=$(az ad app credential reset \
-  --id "$APP_ID" --only-show-errors --output json)
-CLIENT_SECRET=$(echo $SECRET | jq -r '.password')
-
-# 3. Get tenant ID
-TENANT_ID=$(az account list \
-  --query "[?isDefault].tenantId | [0]" \
-  --only-show-errors --output tsv)
-
-# 4. Create service principal
-az ad sp create --id "$APP_ID" --output none
+az account show --query "{tenantId:tenantId, tenantDomain:tenantDefaultDomain, subscription:name}" --output table
 ```
 
-Config output (store secret in Key Vault or environment secret store — never in source):
+If the active tenant does not match the intended tenant, switch first:
+
+```bash
+az login --tenant <intended-tenant-domain-or-id>
+az account set --subscription "<subscription-id>"
+```
+
+**Ask the user for:**
+- `APP_NAME` — display name for the Entra app registration (must be unique in the tenant)
+- `RESOURCE_GROUP` — run the command below to show available resource groups, then ask the user to pick one:
+
+```bash
+az group list --query "[].{Name:name, Location:location}" --output table
+```
+
+- Config format — ask: **"Which config format do you need — dotnet (`appsettings.json`) or Node.js (`.env`)?"**
+
+**Step 1 — Check if app already exists (handle re-run after partial failure):**
+
+```bash
+EXISTING_APP_ID=$(az ad app list --display-name "$APP_NAME" --query "[0].appId" -o tsv)
+if [ -n "$EXISTING_APP_ID" ]; then
+  echo "App '$APP_NAME' already exists (appId: $EXISTING_APP_ID) — resuming."
+  APP_ID="$EXISTING_APP_ID"
+  # Re-derive scope ID from the existing app rather than generating a new GUID
+  OAUTH_SCOPE_ID=$(az ad app show --id "$APP_ID" \
+    --query "api.oauth2PermissionScopes[?value=='access_as_user'].id | [0]" -o tsv)
+  if [ -z "$OAUTH_SCOPE_ID" ]; then
+    echo "ERROR: Existing app has no 'access_as_user' scope. Delete the app and re-run."
+    exit 1
+  fi
+  echo "Re-using OAUTH_SCOPE_ID: $OAUTH_SCOPE_ID — skipping Phase 1, proceeding to Phase 2."
+fi
+```
+
+**Phase 1 — Create app registration with `access_as_user` scope and identifier URI:**
+
+> **Skip this phase if APP_ID and OAUTH_SCOPE_ID are already set** from the resume block above — the app registration already exists.
+
+```bash
+# Acquire owner object ID from the signed-in user
+OWNER_OBJECT_ID=$(az ad signed-in-user show --query id -o tsv)
+
+# Generate a new GUID for the OAuth scope (use PowerShell on Windows)
+OAUTH_SCOPE_ID=$(powershell -NoProfile -Command "[guid]::NewGuid().ToString()")
+
+RESULT=$(az deployment group create \
+  --resource-group "$RESOURCE_GROUP" \
+  --template-file ".claude\skills\azure-agents-sdk-provision\Create_SSO_AppRegistration.bicep" \
+  --parameters "APP_NAME=$APP_NAME" "OWNER_OBJECT_ID=$OWNER_OBJECT_ID" "OAUTH_SCOPE_ID=$OAUTH_SCOPE_ID" \
+  --output json)
+
+APP_ID=$(echo $RESULT | jq -r '.properties.outputs.newAppId.value')
+```
+
+**Phase 2 — Pre-authorize Teams/Office host clients for SSO:**
+
+```bash
+az deployment group create \
+  --resource-group "$RESOURCE_GROUP" \
+  --template-file ".claude\skills\azure-agents-sdk-provision\Create_SSO_PreAuthorize.bicep" \
+  --parameters "APP_NAME=$APP_NAME" "OAUTH_SCOPE_ID=$OAUTH_SCOPE_ID"
+```
+
+**Phase 2b — Verify deployment:**
+
+Run after Phase 2 completes. All three checks must pass before generating a secret.
+
+```bash
+echo "=== Verifying app registration ==="
+
+IDENTIFIER_URI=$(az ad app show --id "$APP_ID" --query "identifierUris[0]" -o tsv)
+[ "$IDENTIFIER_URI" = "api://botid-$APP_ID" ] \
+  && echo "PASS  Identifier URI: $IDENTIFIER_URI" \
+  || echo "FAIL  Identifier URI — expected 'api://botid-$APP_ID', got '$IDENTIFIER_URI'"
+
+SCOPE_CHECK=$(az ad app show --id "$APP_ID" \
+  --query "api.oauth2PermissionScopes[?value=='access_as_user'].id | [0]" -o tsv)
+[ -n "$SCOPE_CHECK" ] \
+  && echo "PASS  access_as_user scope present (id: $SCOPE_CHECK)" \
+  || echo "FAIL  access_as_user scope missing"
+
+PRE_AUTH_COUNT=$(az ad app show --id "$APP_ID" \
+  --query "length(api.preAuthorizedApplications)" -o tsv 2>/dev/null || echo 0)
+[ "${PRE_AUTH_COUNT:-0}" -ge 9 ] \
+  && echo "PASS  Pre-authorized clients: $PRE_AUTH_COUNT" \
+  || echo "FAIL  Pre-authorized clients: ${PRE_AUTH_COUNT:-0} (expected 9 — re-run Phase 2)"
+```
+
+If any check fails, do not proceed. Re-run the failed phase before continuing.
+
+**Phase 3 — Register service principal and create client secret:**
+
+```bash
+# Ignore "already in use" error if the service principal already exists
+az ad sp create --id "$APP_ID" --output none
+
+# --append adds the new secret alongside any existing ones (safe for running bots)
+SECRET_RESULT=$(az ad app credential reset \
+  --id "$APP_ID" \
+  --append \
+  --output json)
+
+CLIENT_SECRET=$(echo $SECRET_RESULT | jq -r '.password')
+TENANT_ID=$(echo $SECRET_RESULT | jq -r '.tenant')
+
+# Retrieve the expiry date of the generated secret
+SECRET_EXPIRY=$(az ad app credential list --id "$APP_ID" --query "[0].endDateTime" -o tsv)
+```
+
+Record these values — `CLIENT_SECRET` is **not retrievable again**:
+- `APP_ID` — App ID (Client ID)
+- `CLIENT_SECRET` — client secret
+- `TENANT_ID` — tenant ID
+- `SECRET_EXPIRY` — secret expiry date (rotate before this date or the bot stops authenticating)
+
+Always surface the expiry date prominently in the output to the user.
+
+**Config output — dotnet (`appsettings.json`):**
+
+Store secret in Key Vault or environment secret store — never in source.
+
 ```json
 {
-  "ClientId": "<appId>",
-  "TenantId": "<tenantId>",
-  "AzureBotAppType": "SingleTenant",
-  "ServiceConnection.Settings": {
-    "AuthType": "ClientSecret",
-    "AuthorityEndpoint": "https://login.microsoftonline.com/<tenantId>",
-    "ClientId": "<appId>",
-    "ClientSecret": "<secret>",
-    "Scopes": ["https://api.botframework.com/.default"]
+  "Connections": {
+    "ServiceConnection": {
+      "Settings": {
+        "AuthType": "ClientSecret",
+        "AuthorityEndpoint": "https://login.microsoftonline.com/<tenantId>",
+        "ClientId": "<appId>",
+        "ClientSecret": "<secret>",
+        "Scopes": ["https://api.botframework.com/.default"]
+      }
+    }
   }
 }
+```
+
+**Config output — Node.js (`.env`):**
+
+```
+connections__serviceConnection__settings__clientId=<appId>
+connections__serviceConnection__settings__clientSecret=<secret>
+connections__serviceConnection__settings__tenantId=<tenantId>
+connectionsMap__0__connection=serviceConnection
+connectionsMap__0__serviceUrl=*
+```
+
+> Run with: `node --env-file .env dist/index.js` (Node 20+)
+
+**Teams app manifest snippet (`manifest.json`):**
+
+Add this block to enable SSO in Teams. The `resource` value must match the identifier URI set on the app registration.
+
+```json
+"webApplicationInfo": {
+  "id": "<appId>",
+  "resource": "api://botid-<appId>"
+}
+```
+
+**Secret rotation (for existing bots):**
+
+Do **not** use `az ad app credential reset` without `--append` on a running bot — it immediately invalidates all existing secrets and causes downtime. The safe rotation pattern is:
+
+```bash
+# Step 1 — Add a NEW secret alongside the existing one (--append keeps old secret live)
+NEW_SECRET_RESULT=$(az ad app credential reset \
+  --id "$APP_ID" \
+  --append \
+  --output json)
+# Record the new secret and its key ID
+NEW_SECRET=$(echo $NEW_SECRET_RESULT | jq -r '.password')
+NEW_KEY_ID=$(az ad app credential list --id "$APP_ID" \
+  --query "sort_by(@, &endDateTime)[-1].keyId" -o tsv)
+
+# Step 2 — Deploy the new secret to config/Key Vault, verify the bot is healthy
+
+# Step 3 — Remove the OLD secret by its key ID (list first to find it)
+az ad app credential list --id "$APP_ID" --query "[].{keyId:keyId, expiry:endDateTime}" -o table
+OLD_KEY_ID=<keyId of the old secret from the table above>
+az ad app credential delete --id "$APP_ID" --key-id "$OLD_KEY_ID"
 ```
 
 ---
@@ -341,24 +501,126 @@ az ad app federated-credential create \
     \"audiences\": [\"api://AzureADTokenExchange\"]
   }"
 
-# 4. Register OAuth connection on bot
+# 4. Set application ID URI and create the access_as_user scope
+az ad app update \
+  --id "$OAUTH_APP_ID" \
+  --identifier-uris "api://botid-$OAUTH_APP_ID"
+
+OAUTH_OBJECT_ID=$(az ad app show --id "$OAUTH_APP_ID" --query id --output tsv)
+# uuidgen on Linux/macOS/WSL; python3 fallback for Windows Git Bash
+SCOPE_ID=$(uuidgen 2>/dev/null || python3 -c "import uuid; print(uuid.uuid4())")
+
+az rest --method PATCH \
+  --uri "https://graph.microsoft.com/v1.0/applications/$OAUTH_OBJECT_ID" \
+  --headers "Content-Type=application/json" \
+  --body "{
+    \"api\": {
+      \"oauth2PermissionScopes\": [{
+        \"id\": \"$SCOPE_ID\",
+        \"adminConsentDescription\": \"Allow the app to access the bot on behalf of the signed-in user.\",
+        \"adminConsentDisplayName\": \"Access the bot as a user\",
+        \"isEnabled\": true,
+        \"type\": \"User\",
+        \"userConsentDescription\": \"Allow this app to access the bot on your behalf.\",
+        \"userConsentDisplayName\": \"Access the bot as a user\",
+        \"value\": \"access_as_user\"
+      }]
+    }
+  }"
+
+# 5. Register OAuth connection on bot
 az bot authsetting create \
   --resource-group "$RESOURCE_GROUP" \
   --name "$BOT_NAME" \
   --setting-name "$OAUTH_CONNECTION_NAME" \
   --client-id "$OAUTH_APP_ID" \
   --client-secret "" \
-  --provider-scope-string "api://${OAUTH_APP_ID}/user_impersonation" \
+  --provider-scope-string "api://${OAUTH_APP_ID}/access_as_user" \
   --service "Aadv2WithFic" \
   --parameters \
     tenantId="$TENANT_ID" \
     tokenExchangeUrl="api://${OAUTH_APP_ID}" \
     federatedClientId="$MSI_CLIENT_ID"
+
+# 6. Add redirect URI to OAuth app registration
+az ad app update \
+  --id "$OAUTH_APP_ID" \
+  --web-redirect-uris "https://token.botframework.com/.auth/web/redirect"
 ```
 
 ### Teams SSO (optional)
 
-After step 2, expose `access_as_user` scope on the OAuth app and add Teams client app IDs as authorized client applications via the Azure Portal (Entra ID > App Registrations > Expose an API).
+Pre-authorize the Teams client apps to allow silent token acquisition. The `access_as_user` scope was created in step 4 above and `SCOPE_ID`/`OAUTH_OBJECT_ID` must still be set in the same shell session.
+
+```bash
+az rest --method PATCH \
+  --uri "https://graph.microsoft.com/v1.0/applications/$OAUTH_OBJECT_ID" \
+  --headers "Content-Type=application/json" \
+  --body "{
+    \"api\": {
+      \"preAuthorizedApplications\": [
+        { \"appId\": \"1fec8e78-bce4-4aaf-ab1b-5451cc387264\", \"delegatedPermissionIds\": [\"$SCOPE_ID\"] },
+        { \"appId\": \"5e3ce6c0-2b1f-4285-8d4b-75ee78787346\", \"delegatedPermissionIds\": [\"$SCOPE_ID\"] },
+        { \"appId\": \"d3590ed6-52b3-4102-aeff-aad2292ab01c\", \"delegatedPermissionIds\": [\"$SCOPE_ID\"] },
+        { \"appId\": \"bc59ab01-8403-45c6-8796-ac3ef710b3e3\", \"delegatedPermissionIds\": [\"$SCOPE_ID\"] },
+        { \"appId\": \"0ec893e0-5785-4de6-99da-4ed124e5296c\", \"delegatedPermissionIds\": [\"$SCOPE_ID\"] },
+        { \"appId\": \"4765445b-32c6-49b0-83e6-1d93765276ca\", \"delegatedPermissionIds\": [\"$SCOPE_ID\"] },
+        { \"appId\": \"27922004-5251-4030-b22d-91ecd9a37ea4\", \"delegatedPermissionIds\": [\"$SCOPE_ID\"] },
+        { \"appId\": \"00000002-0000-0ff1-ce00-000000000000\", \"delegatedPermissionIds\": [\"$SCOPE_ID\"] },
+        { \"appId\": \"4345a7b9-9a63-4910-a426-35363201d503\", \"delegatedPermissionIds\": [\"$SCOPE_ID\"] }
+      ]
+    }
+  }"
+```
+
+These are the Microsoft host client app IDs that must be pre-authorized for SSO to work across all Teams and Office surfaces:
+
+| App ID | Client |
+|--------|--------|
+| `1fec8e78-bce4-4aaf-ab1b-5451cc387264` | Teams desktop / mobile |
+| `5e3ce6c0-2b1f-4285-8d4b-75ee78787346` | Teams web |
+| `d3590ed6-52b3-4102-aeff-aad2292ab01c` | Microsoft Office desktop |
+| `bc59ab01-8403-45c6-8796-ac3ef710b3e3` | Teams iOS |
+| `0ec893e0-5785-4de6-99da-4ed124e5296c` | Office Mobile (iOS) |
+| `4765445b-32c6-49b0-83e6-1d93765276ca` | Microsoft Teams (secondary client) |
+| `27922004-5251-4030-b22d-91ecd9a37ea4` | Skype for Business Online |
+| `00000002-0000-0ff1-ce00-000000000000` | Microsoft Office (Outlook Web / legacy) |
+| `4345a7b9-9a63-4910-a426-35363201d503` | Office Online |
+
+> **If starting a new session**, re-derive the variables before running the above:
+> ```bash
+> OAUTH_OBJECT_ID=$(az ad app show --id "$OAUTH_APP_ID" --query id --output tsv)
+> SCOPE_ID=$(az ad app show --id "$OAUTH_APP_ID" \
+>   --query "api.oauth2PermissionScopes[?value=='access_as_user'].id | [0]" --output tsv)
+> ```
+
+### API Permissions (optional)
+
+Add delegated Microsoft Graph permissions when the bot calls the Graph API on behalf of the signed-in user:
+
+```bash
+# Add delegated permissions (00000003-... is the well-known Graph API app ID)
+az ad app permission add \
+  --id "$OAUTH_APP_ID" \
+  --api 00000003-0000-0000-c000-000000000000 \
+  --api-permissions \
+    e1fe6dd8-ba31-4d61-89e7-88639da4683d=Scope \
+    37f7f235-527c-4136-accd-4a02d197296e=Scope \
+    14dad69e-099b-42c9-810b-d002981feec1=Scope
+
+# Grant admin consent (requires Global Admin or Privileged Role Admin)
+az ad app permission admin-consent --id "$OAUTH_APP_ID"
+```
+
+Common delegated Graph permission IDs:
+
+| Permission | GUID |
+|---|---|
+| `User.Read` | `e1fe6dd8-ba31-4d61-89e7-88639da4683d` |
+| `openid` | `37f7f235-527c-4136-accd-4a02d197296e` |
+| `profile` | `14dad69e-099b-42c9-810b-d002981feec1` |
+| `email` | `64a6cdd6-aab1-4aad-a773-0ae5ec9b9f9b` |
+| `offline_access` | `7427e0e9-2fba-42fe-b0c0-848c9e6a8182` |
 
 ### Exchangeable Token (optional)
 
@@ -371,12 +633,19 @@ Add `--parameters exchangeableToken="true"` to the `az bot authsetting create` c
 | Mistake | Fix |
 |---------|-----|
 | Using `az bot create` | Broken — hardcodes retired API version `2021-05-01-preview`. Use `az rest --method PUT` with `api-version=2022-09-15` instead (see Step 2) |
+| Wrong tenant active in `az` session | Run `az account show` before starting and verify `tenantDefaultDomain` matches the intended tenant — commands silently succeed in the wrong tenant |
+| Duplicate app name | Run `az ad app list --display-name "$APP_NAME"` before deploying — duplicate names cause confusing Bicep errors |
 | FIC subject uses `clientId` | Use `principalId` (object ID) from `az identity create` |
 | Skipped `az ad sp create` | Always create service principal after `az ad app create` |
 | Wrong `app-type` | `UserAssignedMSI` for MSI bots; `SingleTenant` for app-reg bots |
 | Client secret committed to source | Use Key Vault, env secrets, or GitHub Secrets |
+| Secret expiry not tracked | Always retrieve and surface the expiry date with `az ad app credential list --id "$APP_ID" --query "[0].endDateTime"` — default is ~1 year |
+| `credential reset` without `--append` on a running bot | Immediately invalidates all existing secrets — causes downtime. Always use `--append`, deploy the new secret, then delete the old key ID |
+| Re-running Phase 1 with a new GUID after a partial failure | Generates a second `access_as_user` scope on the existing app. Instead, re-derive `OAUTH_SCOPE_ID` from the existing app (see Step 1 resume block) |
 | OAuth app not found | Run `az ad sp create --id <oauth-appId>` if bot can't find the app |
-| `AADSTS500113: No reply address is registered` | Add `https://token.botframework.com/.auth/web/redirect` as a redirect URI on the app registration |
+| `AADSTS500113: No reply address is registered` | Add `https://token.botframework.com/.auth/web/redirect` as a redirect URI on the app registration — applies to **both** ClientSecret and FIC OAuth app registrations |
+| Teams SSO token exchange fails silently | The `access_as_user` scope must be created on the OAuth app registration (step 4 of FIC flow) **before** pre-authorizing Teams clients; and `--provider-scope-string` must reference `access_as_user`, not `user_impersonation` |
+| `uuidgen: command not found` on Windows Git Bash | Use `python3 -c "import uuid; print(uuid.uuid4())"` instead of `uuidgen` |
 
 ## Contributing
 

--- a/agent-plugins/agents-for-js/skills/azure-agents-sdk-provision/bicepconfig.json
+++ b/agent-plugins/agents-for-js/skills/azure-agents-sdk-provision/bicepconfig.json
@@ -1,0 +1,5 @@
+{
+  "extensions": {
+    "microsoftGraph": "br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:1.0.0"
+  }
+}


### PR DESCRIPTION
This pull request introduces a complete, automated, and repeatable process for creating and configuring an Azure Entra ID App Registration for a bot with Teams SSO support, using Bicep templates and improved documentation. The changes provide Bicep scripts for app registration and SSO pre-authorization, update the provisioning process for Azure Bot Services, and significantly enhance the documentation for client secret authentication, secret rotation, and Teams SSO setup.

**Bicep templates for App Registration and SSO:**

- **New Bicep template for initial App Registration:** Adds `Create_SSO_AppRegistration.bicep` to automate creation of an Entra ID App Registration with Teams SSO support, including required Microsoft Graph permissions and the `access_as_user` scope.
- **New Bicep template for SSO pre-authorization:** Adds `Create_SSO_PreAuthorize.bicep` to pre-authorize all necessary Microsoft Teams and Office client applications for SSO, ensuring seamless user authentication in Teams.

**Azure Bot Service provisioning:**

- **Provisioning script for Azure Bot Service:** Introduces `ProvisionABS.bicep` to automate deployment of the Azure Bot Service resource and registration of the Teams channel, parameterized for reusability.

**Documentation improvements and secret management:**

- **Greatly expanded SSO and client secret documentation:** Updates `SKILL.md` to provide a step-by-step, idempotent process for creating the app registration, handling partial failures, generating and rotating client secrets, and producing configuration outputs for both .NET and Node.js. Adds explicit instructions for verifying configuration and safe secret rotation. [[1]](diffhunk://#diff-8509c12bdfd90911e10817f0057f41a71fe078cf450d7bf995895ca026cf2db0R69-R76) [[2]](diffhunk://#diff-8509c12bdfd90911e10817f0057f41a71fe078cf450d7bf995895ca026cf2db0R162-R355)
- **Detailed Teams SSO and API permissions guidance:** Documents the process for exposing the `access_as_user` scope, pre-authorizing Teams and Office client apps, and adding delegated Microsoft Graph permissions, including all required app IDs and permission GUIDs.