### PR TITLE
Small tweaks to Python sample READMEs

### DIFF
--- a/samples/python/README.md
+++ b/samples/python/README.md
@@ -6,7 +6,7 @@
 |Auto Sign In|Simple OAuth agent using Graph and GitHub|[auto-signin](auto-signin/README.md)|
 |OBO Authorization|OBO flow to access a Copilot Studio Agent|[obo-authorization](obo-authorization/README.md)|
 |Semantic Kernel Integration|A weather agent built with Semantic Kernel|[semantic-kernel-multiturn](semantic-kernel-multiturn/README.md)|
-|Streaming Agent|Streams OpenAI responses|[azure-ai-streaming](azure-ai-streaming/README.md)|
+|Streaming Agent|Streams OpenAI responses|[azureai-streaming](azureai-streaming/README.md)|
 |Copilot Studio Client|Console app to consume a Copilot Studio Agent|[copilotstudio-client](copilotstudio-client/README.md)|
 |Cards Agent|Agent that uses rich cards to enhance conversation design |[cards](cards/README.md)|
 |Copilot Studio Skill|Call the echo bot from a Copilot Studio skill |[copilotstudio-skill](copilotstudio-skill/README.md)|

--- a/samples/python/copilotstudio-client/README.md
+++ b/samples/python/copilotstudio-client/README.md
@@ -54,7 +54,11 @@ This step will require permissions to create application identities in your Azur
         2. Search for `Power Platform API`.
             1. *If you do not see `Power Platform API` see the note at the bottom of this section.*
         3. In the *Delegated permissions* list, choose `CopilotStudio` and Check `CopilotStudio.Copilots.Invoke`
-        4. Click `Add Permissions`
+        4. Click `Add permissions`
+    3. Click Add Permission again
+        1. Click on `Microsoft Graph`.
+        2. In the *Delegated permissions* list, choose 'User' and Check `User.Read`
+        3. Click `Add permissions` 
     4. (Optional) Click `Grant Admin consent for copilotsdk`
 
 > [!TIP]
@@ -74,7 +78,10 @@ With the above information, you can now run the client `CopilostStudioClient` sa
   COPILOTSTUDIOAGENT__AGENTAPPID="" # App ID of the App Registration used to login, this should be in the same tenant as the CopilotStudio environment.
 ```
 
-3. After installing the dependencies with `pip install -r requirements.txt`, run the CopilotStudioClient sample using
+3. (Optional but recommended) Set up virtual environment and activate it.
+
+
+4. After installing the dependencies with `pip install -r requirements.txt`, run the CopilotStudioClient sample using
 
 ```sh
 python -m src.main


### PR DESCRIPTION
This PR addresses [a known issue](https://github.com/microsoft/Agents-for-python/issues/285) in the documented setup for the `copilotstudio-client` sample, and fixes a broken link the sample list.