### PR TITLE
Remove icon name fallback logic in CitationEntityProcessor

### DIFF
--- a/samples/dotnet/genesys-handoff/GenesysHandoff.csproj
+++ b/samples/dotnet/genesys-handoff/GenesysHandoff.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>

--- a/samples/dotnet/genesys-handoff/Services/CitationEntityProcessor.cs
+++ b/samples/dotnet/genesys-handoff/Services/CitationEntityProcessor.cs
@@ -44,7 +44,6 @@ namespace GenesysHandoff.Services
                                 continue;
                             }
 
-                            var clientCitationIconName = GetIconNameOrDefault(clientCitation.Appearance.Image?.Name);
 
                             annotation.Citation.Add(new ClientCitation(
                                 clientCitation.Position,
@@ -53,7 +52,7 @@ namespace GenesysHandoff.Services
                                 clientCitation.Appearance.Text ?? string.Empty,
                                 null,
                                 clientCitation.Appearance.Url,
-                                clientCitationIconName
+                                clientCitation.Appearance.Image?.Name
                             ));
                         }
                         filteredEntities.Add(annotation);
@@ -70,25 +69,6 @@ namespace GenesysHandoff.Services
                 }
             }
             return filteredEntities;
-        }
-
-        /// <summary>
-        /// Gets the icon name from the appearance image, defaulting to Image if the value is unknown or invalid.
-        /// </summary>
-        private static ClientCitationIconName GetIconNameOrDefault(ClientCitationIconName? iconName)
-        {
-            if (iconName == null)
-            {
-                return ClientCitationIconName.Image;
-            }
-
-            // Check if the enum value is defined, otherwise use default
-            if (!Enum.IsDefined(typeof(ClientCitationIconName), iconName))
-            {
-                return ClientCitationIconName.Image;
-            }
-
-            return iconName;
         }
     }
 }


### PR DESCRIPTION
Removed GetIconNameOrDefault and its usage when assigning icon names to ClientCitation. Now, the code directly uses the image name without providing a default fallback if the value is null or invalid. No other logic was changed.