### PR TITLE
Add configurable disconnect messages and restrict escalated handling

### DIFF
--- a/samples/dotnet/genesys-handoff/Genesys/GenesysConnectionSetting.cs
+++ b/samples/dotnet/genesys-handoff/Genesys/GenesysConnectionSetting.cs
@@ -54,6 +54,16 @@ namespace GenesysHandoff.Genesys
         public bool EnableNotifications { get; set; }
 
         /// <summary>
+        /// Gets or sets the message sent to the user when a live agent disconnects.
+        /// </summary>
+        public string? AgentDisconnectedMessage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the label shown on the suggested action button that ends the live chat.
+        /// </summary>
+        public string? EndLiveChatMessage { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="GenesysConnectionSetting"/> class.
         /// </summary>
         public GenesysConnectionSetting() { }
@@ -78,6 +88,8 @@ namespace GenesysHandoff.Genesys
                 ClientSecret = config.GetValue<string>("ClientSecret");
                 WebhookSignatureSecret = config.GetValue<string>("WebhookSignatureSecret");
                 EnableNotifications = config.GetValue<bool>("EnableNotifications");
+                AgentDisconnectedMessage = config.GetValue<string>("AgentDisconnectedMessage");
+                EndLiveChatMessage = config.GetValue<string>("EndLiveChatMessage");
             }
         }
     }

--- a/samples/dotnet/genesys-handoff/Genesys/GenesysNotificationService.cs
+++ b/samples/dotnet/genesys-handoff/Genesys/GenesysNotificationService.cs
@@ -293,15 +293,18 @@ namespace GenesysHandoff.Genesys
                 // Proactively notify the Teams user
                 var continuationActivity = userChannelReference.GetContinuationActivity();
                 var claimsIdentity = AgentClaims.CreateIdentity(userChannelReference.Agent.Id);
+                var audience = string.IsNullOrWhiteSpace(userChannelReference.ServiceUrl)
+                    ? AuthenticationConstants.BotFrameworkAudience
+                    : userChannelReference.ServiceUrl;
 
                 await _channelAdapter.ProcessProactiveAsync(
                     claimsIdentity: claimsIdentity,
                     continuationActivity: continuationActivity,
-                    audience: string.Empty,
+                    audience: audience,
                     callback: async (turnContext, ct) =>
                     {
                         await turnContext.SendActivityAsync(
-                            MessageFactory.Text("The live agent has left the conversation. You are now back with the bot."),
+                            MessageFactory.Text(_settings.AgentDisconnectedMessage ?? "The live agent has left the conversation. You are now back with the bot."),
                             cancellationToken: ct);
                     },
                     cancellationToken: cancellationToken);

--- a/samples/dotnet/genesys-handoff/Genesys/GenesysWebhookHandler.cs
+++ b/samples/dotnet/genesys-handoff/Genesys/GenesysWebhookHandler.cs
@@ -116,11 +116,14 @@ namespace GenesysHandoff.Genesys
         {
             var continuationActivity = userChannelReference.GetContinuationActivity();
             var claimsIdentity = AgentClaims.CreateIdentity(userChannelReference.Agent.Id);
+            var audience = string.IsNullOrWhiteSpace(userChannelReference.ServiceUrl)
+                    ? AuthenticationConstants.BotFrameworkAudience
+                    : userChannelReference.ServiceUrl;
 
             await channelAdapter.ProcessProactiveAsync(
                 claimsIdentity: claimsIdentity,
                 continuationActivity: continuationActivity,
-                audience: string.Empty,
+                audience: audience,
                 callback: async (turnContext, ct) =>
                 {
                     await turnContext.SendActivityAsync(activity, cancellationToken: ct);
@@ -128,16 +131,15 @@ namespace GenesysHandoff.Genesys
                 cancellationToken: cancellationToken);
         }
 
-        private const string EndLiveChatAction = "End chat with agent";
-
-        private static IActivity BuildAgentReply(GenesysOutboundPayload payload)
+        private IActivity BuildAgentReply(GenesysOutboundPayload payload)
         {
+            var endChatLabel = _setting.EndLiveChatMessage ?? "End chat with agent";
             var replyActivity = MessageFactory.Text($"[Live Agent] - {payload.Text}");
             replyActivity.SuggestedActions = new SuggestedActions
             {
                 Actions = new List<CardAction>
                 {
-                    new() { Title = EndLiveChatAction, Type = ActionTypes.ImBack, Value = EndLiveChatAction }
+                    new() { Title = endChatLabel, Type = ActionTypes.ImBack, Value = endChatLabel }
                 }
             };
 

--- a/samples/dotnet/genesys-handoff/Genesys/IGenesysConnectionSettings.cs
+++ b/samples/dotnet/genesys-handoff/Genesys/IGenesysConnectionSettings.cs
@@ -43,5 +43,15 @@ namespace GenesysHandoff.Genesys
         /// Gets or sets whether the Genesys WebSocket notification service is enabled for detecting agent disconnections.
         /// </summary>
         public bool EnableNotifications { get; set; }
+
+        /// <summary>
+        /// Gets or sets the message sent to the user when a live agent disconnects.
+        /// </summary>
+        public string? AgentDisconnectedMessage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the label shown on the suggested action button that ends the live chat.
+        /// </summary>
+        public string? EndLiveChatMessage { get; set; }
     }
 }

--- a/samples/dotnet/genesys-handoff/GenesysHandoffAgent.cs
+++ b/samples/dotnet/genesys-handoff/GenesysHandoffAgent.cs
@@ -20,8 +20,8 @@ namespace GenesysHandoff
     public class GenesysHandoffAgent : AgentApplication
     {
         private const string McsHandlerName = "mcs";
-        private const string EndLiveChatAction = "End chat with agent";
 
+        private readonly string _endLiveChatMessage;
         private readonly GenesysMessageSender _messageSender;
         private readonly CopilotClientFactory _copilotClientFactory;
         private readonly ActivityResponseProcessor _responseProcessor;
@@ -38,9 +38,11 @@ namespace GenesysHandoff
             CopilotClientFactory copilotClientFactory,
             ActivityResponseProcessor responseProcessor,
             ConversationStateManager stateManager,
+            IGenesysConnectionSettings settings,
             ILogger<GenesysHandoffAgent> logger,
             GenesysNotificationService? notificationService = null) : base(options)
         {
+            _endLiveChatMessage = settings.EndLiveChatMessage ?? "End chat with agent";
             _messageSender = messageSender;
             _copilotClientFactory = copilotClientFactory;
             _responseProcessor = responseProcessor;
@@ -105,7 +107,7 @@ namespace GenesysHandoff
                     else
                     {
                         // Check if the user clicked the "End chat with agent" suggested action
-                        if (string.Equals(turnContext.Activity.Text, EndLiveChatAction, StringComparison.OrdinalIgnoreCase))
+                        if (string.Equals(turnContext.Activity.Text, _endLiveChatMessage, StringComparison.OrdinalIgnoreCase))
                         {
                             await DisconnectFromLiveAgent(turnContext, turnState, mcsConversationId, cancellationToken);
                         }

--- a/samples/dotnet/genesys-handoff/GenesysHandoffAgent.cs
+++ b/samples/dotnet/genesys-handoff/GenesysHandoffAgent.cs
@@ -93,7 +93,7 @@ namespace GenesysHandoff
             else if (turnContext.Activity.IsType(ActivityTypes.Message) || turnContext.Activity.IsType(ActivityTypes.Invoke))
             {
                 var isEscalated = _stateManager.IsEscalated(turnState);
-                if (isEscalated)
+                if (isEscalated && !turnContext.Activity.IsType(ActivityTypes.Invoke))
                 {
                     // Check if the agent has disconnected since our last turn
                     if (_notificationService != null

--- a/samples/dotnet/genesys-handoff/README.md
+++ b/samples/dotnet/genesys-handoff/README.md
@@ -204,7 +204,9 @@ Update appsettings.json with the details collected from the Genesys setup steps:
   "ClientId": "",                   // OAuth Client ID created in Genesys
   "ClientSecret": "",               // OAuth Client Secret created in Genesys
   "WebhookSignatureSecret": "",     // Required: outboundNotificationWebhookSignatureSecretToken from Genesys integration
-  "EnableNotifications": true        // Enable WebSocket notifications for automatic agent disconnect detection
+  "EnableNotifications": true,      // Enable WebSocket notifications for automatic agent disconnect detection
+  "AgentDisconnectedMessage": "The live agent has left the conversation. You are now back with the bot.", // Optional: message sent to user when the live agent disconnects
+  "EndLiveChatMessage": "End chat with agent" // Optional: label for the suggested action button that ends the live chat
 }
 ```
 

--- a/samples/dotnet/genesys-handoff/Services/CitationEntityProcessor.cs
+++ b/samples/dotnet/genesys-handoff/Services/CitationEntityProcessor.cs
@@ -44,6 +44,11 @@ namespace GenesysHandoff.Services
                                 continue;
                             }
 
+                            var imageName = clientCitation.Appearance.Image?.Name?.ToString();
+                            if (string.IsNullOrWhiteSpace(imageName) || string.Equals(imageName, "Unknown", StringComparison.OrdinalIgnoreCase))
+                            {
+                                imageName = "Image";
+                            }
 
                             annotation.Citation.Add(new ClientCitation(
                                 clientCitation.Position,
@@ -52,7 +57,7 @@ namespace GenesysHandoff.Services
                                 clientCitation.Appearance.Text ?? string.Empty,
                                 null,
                                 clientCitation.Appearance.Url,
-                                clientCitation.Appearance.Image?.Name
+                                imageName
                             ));
                         }
                         filteredEntities.Add(annotation);

--- a/samples/dotnet/genesys-handoff/appsettings.json
+++ b/samples/dotnet/genesys-handoff/appsettings.json
@@ -62,6 +62,8 @@
     "ClientSecret": "{{GenesysClientSecret}}",
     "WebhookSignatureSecret": "{{OutboundNotificationWebhookSignatureSecretToken}}" // Optional: outboundNotificationWebhookSignatureSecretToken from Genesys integration
     "EnableNotifications": true // Enable WebSocket notifications for agent disconnect detection
+    "AgentDisconnectedMessage": "The live agent has left the conversation. You are now back with the bot.",
+    "EndLiveChatMessage": "End chat with agent"
   },
 
   "ConnectionsMap": [


### PR DESCRIPTION
This pull request adds new configuration options to customize user-facing messages in the Genesys handoff sample and improves how suggested actions and agent disconnect notifications are handled. It also includes a minor fix to the citation entity processing logic.

**User message customization and configuration:**

* Added new `AgentDisconnectedMessage` and `EndLiveChatMessage` properties to both `IGenesysConnectionSettings` and `GenesysConnectionSetting`, allowing configuration of the message shown to users when a live agent disconnects and the label for the "end chat" suggested action button. These values are now read from configuration and used throughout the codebase. [[1]](diffhunk://#diff-33f85706e3651af5c89eaba6d7c580d6df6e063551fec1caf6e82649eb98d458R56-R65) [[2]](diffhunk://#diff-33f85706e3651af5c89eaba6d7c580d6df6e063551fec1caf6e82649eb98d458R91-R92) [[3]](diffhunk://#diff-043956bba973123e6f250893d2fb1182e3a2d78751b12374e5d78846ff3d3858R46-R55) [[4]](diffhunk://#diff-bee372c868956aa5f5a20e53147811c4a7dd69b26f0312112181c4dc9d42a7e8L207-R209) [[5]](diffhunk://#diff-44d163ee73d106c6498a480b6c826bf07880d525ce13703ba29b4a4d15f78bc4R65-R66)
* Updated the message sent to users when a live agent disconnects to use the new `AgentDisconnectedMessage` setting, falling back to the previous default if not set.

**Suggested action improvements:**

* Updated the label and value of the "End chat with agent" suggested action button to use the configurable `EndLiveChatMessage` value, ensuring consistency between the UI and the text checked in code. [[1]](diffhunk://#diff-71c79335278a084b935a3b475ad487fd36d413e684bd1ade066016837f343d67R119-R142) [[2]](diffhunk://#diff-07e082a6a2e6f54e0f8ff779ce40da84c6189435745a8c142a1e3d1be8851799L23-R24) [[3]](diffhunk://#diff-07e082a6a2e6f54e0f8ff779ce40da84c6189435745a8c142a1e3d1be8851799R41-R45) [[4]](diffhunk://#diff-07e082a6a2e6f54e0f8ff779ce40da84c6189435745a8c142a1e3d1be8851799L94-R96) [[5]](diffhunk://#diff-07e082a6a2e6f54e0f8ff779ce40da84c6189435745a8c142a1e3d1be8851799L108-R110)

**Citation entity processing fix:**

* Improved the citation entity processor to default the citation image name to "Image" if it is missing or set to "Unknown", ensuring more consistent display in the UI. [[1]](diffhunk://#diff-64247bdd7cddb272fde858ae97de26ea6698460ed32b1d92efea6559ed74a1bdR47-R51) [[2]](diffhunk://#diff-64247bdd7cddb272fde858ae97de26ea6698460ed32b1d92efea6559ed74a1bdL55-R60)