### PR TITLE
Fix import statements and update service name in OpenTelemetry config

### DIFF
--- a/samples/python/otel/src/main.py
+++ b/samples/python/otel/src/main.py
@@ -1,12 +1,12 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from telemetry import configure_otel_providers
+from .telemetry import configure_otel_providers
 
-configure_otel_providers(service_name="quickstart_agent")
+configure_otel_providers(service_name="otel_quickstart_agent")
 
-from agent import AGENT_APP, CONNECTION_MANAGER
-from start_server import start_server
+from .agent import AGENT_APP, CONNECTION_MANAGER
+from .start_server import start_server
 
 start_server(
     agent_application=AGENT_APP,


### PR DESCRIPTION
### Summary

This pull request updates import statements in `samples/python/otel/src/main.py` to use relative imports and changes the service name used in the OpenTelemetry configuration. These changes help ensure the code works correctly as a module and improve service naming consistency.

Import improvements:

* Changed all import statements from absolute to relative imports to ensure proper module resolution when running the script as part of a package.

Configuration update:

* Updated the service name in the `configure_otel_providers` call from `"quickstart_agent"` to `"otel_quickstart_agent"` for improved clarity and consistency.

## Testing

Ran locally and verified