### PR TITLE
adding missing samples to the build and covering min/max node version

### DIFF
--- a/.github/workflows/cd-samples.yml
+++ b/.github/workflows/cd-samples.yml
@@ -6,26 +6,41 @@ on:
     branches:
       - main
 
+env:
+  NODE_MINVERSION: '20'
+
 jobs:
-  build:
+  build-dotnet:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Node.js 22
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
-      - name: Install Node dependencies
-        run: npm ci
-
       - name: Build dotnet Samples
         working-directory: ./samples/dotnet
         run: |
           dotnet build
+
+  build-node:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        # NOTE: keep first entry in sync with env.NODE_MINVERSION
+        node-version: [20, 'latest']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install Node dependencies
+        run: npm ci
 
       - name: Run lint
         run: npm run lint
@@ -42,25 +57,25 @@ jobs:
           npm ci
           npm run build
 
-      - name: build Node QuickStart
+      - name: Build Node QuickStart
         working-directory: ./samples/nodejs/quickstart
         run: |
           npm ci
           npm run build
 
-      - name: Build  Node Cards Agent
+      - name: Build Node Cards Agent
         working-directory: ./samples/nodejs/cards/
         run: |
           npm ci
           npm run build
 
-      - name: Build  iamge Node Skill Agent
+      - name: Build Node Skill Agent
         working-directory: ./samples/nodejs/copilotstudio-skill/
         run: |
           npm ci
           npm run build
 
-      - name: Build Node langChain Agent
+      - name: Build Node LangChain Agent
         working-directory: ./samples/nodejs/langchain-multiturn/
         run: |
           npm ci
@@ -72,7 +87,7 @@ jobs:
           npm ci
           npm run build
 
-      - name: Build Node auto signin Agent
+      - name: Build Node Auto Signin Agent
         working-directory: ./samples/nodejs/auto-signin/
         run: |
           npm ci
@@ -80,6 +95,18 @@ jobs:
 
       - name: Build Node OBO Agent
         working-directory: ./samples/nodejs/obo-authorization/
+        run: |
+          npm ci
+          npm run build
+
+      - name: Build Node Copilot SDK sample
+        working-directory: ./samples/nodejs/copilot-sdk/
+        run: |
+          npm ci
+          npm run build
+
+      - name: Build Node Multi-Turn Prompt Agent
+        working-directory: ./samples/nodejs/multi-turn-prompt/
         run: |
           npm ci
           npm run build

--- a/.github/workflows/cd-samples.yml
+++ b/.github/workflows/cd-samples.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   NODE_MINVERSION: '20'
 

--- a/.github/workflows/cd-samples.yml
+++ b/.github/workflows/cd-samples.yml
@@ -11,6 +11,7 @@ permissions:
 
 env:
   NODE_MINVERSION: '20'
+  PYTHON_MINVERSION: '3.10'
 
 jobs:
   build-dotnet:
@@ -48,68 +49,39 @@ jobs:
       - name: Run lint
         run: npm run lint
 
-      - name: Build Node Copilot Studio client sample
-        working-directory: ./samples/nodejs/copilotstudio-client/
+      - name: Build all Node samples
         run: |
-          npm ci
-          npm run build
+          for dir in samples/nodejs/*/; do
+            if [ -f "$dir/package.json" ]; then
+              echo "::group::Building $dir"
+              (cd "$dir" && npm ci && npm run build)
+              echo "::endgroup::"
+            fi
+          done
 
-      - name: Build Node Copilot Studio client - React Webchat sample
-        working-directory: ./samples/nodejs/copilotstudio-webchat-react/
-        run: |
-          npm ci
-          npm run build
+  build-python:
+    runs-on: ubuntu-latest
 
-      - name: Build Node QuickStart
-        working-directory: ./samples/nodejs/quickstart
-        run: |
-          npm ci
-          npm run build
+    strategy:
+      matrix:
+        # NOTE: keep first entry in sync with env.PYTHON_MINVERSION
+        python-version: ['3.10', '3.x']
 
-      - name: Build Node Cards Agent
-        working-directory: ./samples/nodejs/cards/
-        run: |
-          npm ci
-          npm run build
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      - name: Build Node Skill Agent
-        working-directory: ./samples/nodejs/copilotstudio-skill/
-        run: |
-          npm ci
-          npm run build
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
-      - name: Build Node LangChain Agent
-        working-directory: ./samples/nodejs/langchain-multiturn/
+      - name: Build all Python samples
         run: |
-          npm ci
-          npm run build
-
-      - name: Build Node StreamingResponse Agent
-        working-directory: ./samples/nodejs/azure-ai-streaming/
-        run: |
-          npm ci
-          npm run build
-
-      - name: Build Node Auto Signin Agent
-        working-directory: ./samples/nodejs/auto-signin/
-        run: |
-          npm ci
-          npm run build
-
-      - name: Build Node OBO Agent
-        working-directory: ./samples/nodejs/obo-authorization/
-        run: |
-          npm ci
-          npm run build
-
-      - name: Build Node Copilot SDK sample
-        working-directory: ./samples/nodejs/copilot-sdk/
-        run: |
-          npm ci
-          npm run build
-
-      - name: Build Node Multi-Turn Prompt Agent
-        working-directory: ./samples/nodejs/multi-turn-prompt/
-        run: |
-          npm ci
-          npm run build
+          for dir in samples/python/*/; do
+            if [ -f "$dir/requirements.txt" ]; then
+              echo "::group::Building $dir"
+              (cd "$dir" && pip install -r requirements.txt && python -m compileall src/ -q)
+              echo "::endgroup::"
+            fi
+          done


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/cd-samples.yml` to improve sample build automation and clarity. The main changes split the build process for .NET and Node.js samples, introduce a build matrix for Node.js versions, and add or clarify build steps for several sample projects.

**Workflow structure improvements:**

* Split the build job into two separate jobs: `build-dotnet` for .NET samples and `build-node` for Node.js samples, improving clarity and parallelism.
* Introduced a build matrix to test Node.js samples on both version 20 and the latest Node.js, ensuring compatibility.
* Set a minimum Node.js version (`NODE_MINVERSION`) as a workflow environment variable for easier maintenance.

**Sample build steps and naming:**

* Added explicit build steps for new Node.js samples: `copilot-sdk` and `multi-turn-prompt`.
* Standardized and corrected job step names for clarity (e.g., "Build Node QuickStart", "Build Node LangChain Agent", "Build Node Auto Signin Agent"). [[1]](diffhunk://#diff-90a18003d5663374bf652989be3ef71f50399fce3f30ceb75955cd12625976f8L45-R60) [[2]](diffhunk://#diff-90a18003d5663374bf652989be3ef71f50399fce3f30ceb75955cd12625976f8L57-R78) [[3]](diffhunk://#diff-90a18003d5663374bf652989be3ef71f50399fce3f30ceb75955cd12625976f8L75-R90)

These changes enhance the reliability, maintainability, and readability of the CI workflow for sample projects.