### PR TITLE
Update package references to use version wildcards for named-pipe agent

### DIFF
--- a/samples/dotnet/named-pipe-agent/NamedPipeAgent.csproj
+++ b/samples/dotnet/named-pipe-agent/NamedPipeAgent.csproj
@@ -15,9 +15,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<!-- Named-pipe transport currently ships as a 1.6 prerelease (beta) package. -->
-		<PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.6.109-beta" />
-		<PackageReference Include="Microsoft.Agents.Hosting.DirectLine.NamedPipes" Version="1.6.109-beta" />
+		<PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.6.*" />
+		<PackageReference Include="Microsoft.Agents.Hosting.DirectLine.NamedPipes" Version="1.6.*" />
 	</ItemGroup>
 
 </Project>

--- a/samples/nodejs/named-pipe-agent/package-lock.json
+++ b/samples/nodejs/named-pipe-agent/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/agents-hosting": "1.6.0-beta.35.gea39311d63",
-        "@microsoft/agents-hosting-directline-namedpipes": "1.6.0-beta.35.gea39311d63"
+        "@microsoft/agents-hosting": "1.6.*",
+        "@microsoft/agents-hosting-directline-namedpipes": "1.6.*"
       },
       "devDependencies": {
         "@types/node": "^22.15.18",
@@ -80,9 +80,9 @@
       }
     },
     "node_modules/@microsoft/agents-activity": {
-      "version": "1.6.0-beta.35.gea39311d63",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-activity/-/agents-activity-1.6.0-beta.35.gea39311d63.tgz",
-      "integrity": "sha512-CclVrTY5KRVqtkRDH4LLkdC0a4344KSX6yZU5Tl6zHAaay47BDQKUPEUB4bQAM2ycEK9/099DM7pJMIdqpF5ZQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-activity/-/agents-activity-1.6.1.tgz",
+      "integrity": "sha512-EURFWskaCBbsNfMj9w5sbIHUNNyIuig8+/YCqe2hwRNTTG01s/Jd8pvvvurnH+5P55Y2++AsYLnuwvXKP8LhjA==",
       "license": "MIT",
       "dependencies": {
         "zod": "3.25.75"
@@ -92,19 +92,17 @@
       }
     },
     "node_modules/@microsoft/agents-hosting": {
-      "version": "1.6.0-beta.35.gea39311d63",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting/-/agents-hosting-1.6.0-beta.35.gea39311d63.tgz",
-      "integrity": "sha512-UoWOJIF2DBUaFigRRXK58x0hfl9w+n5d2q/KnY5bpw5nUgcESsWfn0iqAKTq3AuEKGaS69PuAjKLYKQyFo+ajQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting/-/agents-hosting-1.6.1.tgz",
+      "integrity": "sha512-qOvuBNIeSrS93KuaWmAFqnjUbvpZhjy/rz9jF8fPE+1rY/Kyi3o+TtODSX5gy1moZ0/nwVwl10XhIXXRF882SQ==",
       "license": "MIT",
       "dependencies": {
         "@azure/core-auth": "1.10.1",
         "@azure/msal-node": "5.1.5",
-        "@microsoft/agents-activity": "1.6.0-beta.35.gea39311d63",
-        "@microsoft/agents-telemetry": "1.6.0-beta.35.gea39311d63",
-        "axios": "1.16.1",
+        "@microsoft/agents-activity": "1.6.1",
+        "@microsoft/agents-telemetry": "1.6.1",
         "jsonwebtoken": "9.0.3",
         "jwks-rsa": "4.0.1",
-        "object-path": "0.11.8",
         "zod": "3.25.75"
       },
       "engines": {
@@ -112,14 +110,14 @@
       }
     },
     "node_modules/@microsoft/agents-hosting-directline-namedpipes": {
-      "version": "1.6.0-beta.35.gea39311d63",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting-directline-namedpipes/-/agents-hosting-directline-namedpipes-1.6.0-beta.35.gea39311d63.tgz",
-      "integrity": "sha512-XDj32xEGiApUepte6speuCpW1l4XVZuH/aFXIknJ3Hy8rPV1yUBlLUMfQt8dy99bETGJeHDxLgqgoS81Vf1Kmw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting-directline-namedpipes/-/agents-hosting-directline-namedpipes-1.6.1.tgz",
+      "integrity": "sha512-ALqBzsu9KQJNA2grBV+Nme3U+sS1zvbDR6vZ9HbMXEo0LigFZWojplE1GSrSknPzE02vre5KweznpTWMXnQqbg==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/agents-activity": "1.6.0-beta.35.gea39311d63",
-        "@microsoft/agents-hosting": "1.6.0-beta.35.gea39311d63",
-        "@microsoft/agents-telemetry": "1.6.0-beta.35.gea39311d63",
+        "@microsoft/agents-activity": "1.6.1",
+        "@microsoft/agents-hosting": "1.6.1",
+        "@microsoft/agents-telemetry": "1.6.1",
         "jsonwebtoken": "9.0.3"
       },
       "engines": {
@@ -127,9 +125,9 @@
       }
     },
     "node_modules/@microsoft/agents-telemetry": {
-      "version": "1.6.0-beta.35.gea39311d63",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-telemetry/-/agents-telemetry-1.6.0-beta.35.gea39311d63.tgz",
-      "integrity": "sha512-T93PAjWNvVABKkiXaxHrH0TFqn+HHJP+66Ly6Y4fVamh8UVPF+lRGl56CRePNOLndMVCM7Q1S7czTl3O/jUFEQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-telemetry/-/agents-telemetry-1.6.1.tgz",
+      "integrity": "sha512-ugbvUyP0PupHcFXTYy3+mXE2QfW13mRY4hrY7HyS3ZWWL20L7RUyg27nXqL4ndaqtuoEt+MPkluEfabG3iJVSg==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3"
@@ -167,9 +165,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
-      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -198,79 +196,11 @@
         "node": ">= 14"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
-        "https-proxy-agent": "^5.0.1",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
-    "node_modules/axios/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/axios/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -289,29 +219,6 @@
         }
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -319,184 +226,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
-      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -665,59 +394,11 @@
         "lru-cache": "^11.0.1"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
-    },
-    "node_modules/object-path": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.8.tgz",
-      "integrity": "sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.12.0"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",

--- a/samples/nodejs/named-pipe-agent/package.json
+++ b/samples/nodejs/named-pipe-agent/package.json
@@ -14,8 +14,8 @@
     "start": "node --env-file .env ./dist/index.js"
   },
   "dependencies": {
-    "@microsoft/agents-hosting": "1.6.0-beta.35.gea39311d63",
-    "@microsoft/agents-hosting-directline-namedpipes": "1.6.0-beta.35.gea39311d63"
+    "@microsoft/agents-hosting": "1.6.*",
+    "@microsoft/agents-hosting-directline-namedpipes": "1.6.*"
   },
   "devDependencies": {
     "@types/node": "^22.15.18",


### PR DESCRIPTION
This pull request updates the dependencies for both the .NET and Node.js named pipe agent samples to use the latest stable 1.6.x versions, removing explicit references to beta packages and cleaning up unused or unnecessary dependencies in the Node.js sample. This helps ensure better stability, maintainability, and compatibility with the latest package releases.

Dependency updates and cleanup:

**.NET sample:**
- Updated `Microsoft.Agents.Hosting.AspNetCore` and `Microsoft.Agents.Hosting.DirectLine.NamedPipes` package references in `NamedPipeAgent.csproj` from a specific beta version to the latest 1.6.x stable version.

**Node.js sample:**
- Updated `@microsoft/agents-hosting` and `@microsoft/agents-hosting-directline-namedpipes` dependencies in both `package.json` and `package-lock.json` from a specific beta version to the latest 1.6.x stable version. [[1]](diffhunk://#diff-051bd867c47488c3b74035d98cfb2c2d3dff83d33760a0e539909ba0aacb2d5fL17-R18) [[2]](diffhunk://#diff-fb688d1e990b7f6ed109f1b4e062889001f99dc1de875f64064c3f629260816cL12-R13)
- Upgraded related dependencies (`@microsoft/agents-activity`, `@microsoft/agents-telemetry`) to stable 1.6.1 releases in `package-lock.json`. [[1]](diffhunk://#diff-fb688d1e990b7f6ed109f1b4e062889001f99dc1de875f64064c3f629260816cL83-R85) [[2]](diffhunk://#diff-fb688d1e990b7f6ed109f1b4e062889001f99dc1de875f64064c3f629260816cL95-R130)
- Upgraded the `@types/node` dev dependency to a newer patch version.
- Removed several unused or unnecessary dependencies from `package-lock.json`, such as `axios`, `object-path`, and their transitive dependencies, streamlining the dependency tree. [[1]](diffhunk://#diff-fb688d1e990b7f6ed109f1b4e062889001f99dc1de875f64064c3f629260816cL201-L274) [[2]](diffhunk://#diff-fb688d1e990b7f6ed109f1b4e062889001f99dc1de875f64064c3f629260816cL292-L314) [[3]](diffhunk://#diff-fb688d1e990b7f6ed109f1b4e062889001f99dc1de875f64064c3f629260816cL324-L501) [[4]](diffhunk://#diff-fb688d1e990b7f6ed109f1b4e062889001f99dc1de875f64064c3f629260816cL668-L721)