### PR TITLE
fix: add resilient SSE streaming and HTTP keep-alive for Copilot Studio

### DIFF
--- a/samples/dotnet/genesys-handoff/GenesysHandoffAgent.Streaming.cs
+++ b/samples/dotnet/genesys-handoff/GenesysHandoffAgent.Streaming.cs
@@ -1,0 +1,207 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Resilient Copilot Studio (MCS) SSE streaming with retry-with-backoff.
+// Fixes: "Unable to read data from the transport connection: An existing
+// connection was forcibly closed by the remote host." errors on long
+// generative turns where an idle-sensitive intermediary RSTs the socket.
+
+using GenesysHandoff.Services;
+using Microsoft.Agents.Builder;
+using Microsoft.Agents.Builder.State;
+using Microsoft.Agents.Core.Models;
+using Microsoft.Extensions.Logging;
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GenesysHandoff
+{
+    public partial class GenesysHandoffAgent
+    {
+        private const int McsStreamMaxAttempts = 3;
+        private static readonly TimeSpan McsStreamBaseDelay = TimeSpan.FromMilliseconds(500);
+
+        // Friendly fallback shown when the Copilot Studio stream cannot be completed after retries.
+        private const string CopilotStreamErrorMessage =
+            "Sorry, I hit a temporary connection problem while getting that answer. Please send your message again.";
+
+        /// <summary>
+        /// Handles starting a new conversation with Copilot Studio.
+        /// StartConversation carries no user turn, so a clean retry on transient
+        /// transport faults is always safe.
+        /// </summary>
+        private async Task<string> HandleNewConversation(
+            ITurnContext turnContext,
+            ITurnState turnState,
+            Microsoft.Agents.CopilotStudio.Client.CopilotClient cpsClient,
+            CancellationToken cancellationToken)
+        {
+            ConversationReference? lastCopilotStudioRef = null;
+
+            for (var attempt = 1; attempt <= McsStreamMaxAttempts; attempt++)
+            {
+                try
+                {
+                    await foreach (IActivity activity in cpsClient.StartConversationAsync(
+                        emitStartConversationEvent: true, cancellationToken: cancellationToken))
+                    {
+                        _logger.LogInformation(
+                            "Activity from CPS (StartConversation): Id={CpsActivityId} ReplyToId={CpsReplyToId} Type={Type} Name={Name} Conversation={ConversationId}",
+                            activity.Id, activity.ReplyToId, activity.Type, activity.Name, activity.Conversation?.Id);
+
+                        lastCopilotStudioRef = activity.GetConversationReference();
+                        if (activity.IsType(ActivityTypes.Message)
+                            && !string.IsNullOrWhiteSpace(activity.Conversation?.Id))
+                        {
+                            _stateManager.SetConversationId(turnState, activity.Conversation.Id);
+                        }
+                    }
+
+                    break; // success
+                }
+                catch (Exception ex) when (IsTransientStreamFault(ex) && !cancellationToken.IsCancellationRequested)
+                {
+                    if (attempt >= McsStreamMaxAttempts)
+                    {
+                        _logger.LogError(
+                            ex,
+                            "Failed to start Copilot Studio conversation after {MaxAttempts} attempts. Surfacing fallback message.",
+                            McsStreamMaxAttempts);
+                        await turnContext.SendActivityAsync(CopilotStreamErrorMessage, cancellationToken: cancellationToken);
+                        return string.Empty;
+                    }
+
+                    var delay = TimeSpan.FromMilliseconds(McsStreamBaseDelay.TotalMilliseconds * Math.Pow(2, attempt - 1));
+                    _logger.LogWarning(
+                        ex,
+                        "Transient reset starting Copilot Studio conversation on attempt {Attempt}/{MaxAttempts}. Retrying in {DelayMs} ms.",
+                        attempt, McsStreamMaxAttempts, (int)delay.TotalMilliseconds);
+                    await Task.Delay(delay, cancellationToken);
+                }
+            }
+
+            if (lastCopilotStudioRef != null)
+            {
+                _stateManager.SetLastCopilotStudioReference(turnState, lastCopilotStudioRef);
+            }
+
+            return lastCopilotStudioRef?.Conversation.Id ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Handles processing messages through Copilot Studio and checking for escalation events.
+        /// Resilient version: transient transport resets on the SSE stream are retried
+        /// (before any assistant reply is surfaced) and never leak to the end user.
+        /// </summary>
+        private async Task HandleCopilotStudioMessage(
+            ITurnContext turnContext,
+            ITurnState turnState,
+            Microsoft.Agents.CopilotStudio.Client.CopilotClient cpsClient,
+            string mcsConversationId,
+            CancellationToken cancellationToken)
+        {
+            var lastCopilotStudioRef = _stateManager.GetLastCopilotStudioReference(turnState);
+            _logger.LogInformation(
+                "Activity from Teams: Id={TeamsActivityId} ReplyToId={TeamsReplyToId} Type={Type} Conversation={ConversationId}",
+                turnContext.Activity.Id, turnContext.Activity.ReplyToId, turnContext.Activity.Type, mcsConversationId);
+
+            var activityToSend = await BuildCopilotStudioActivityAsync(
+                turnContext.Activity, lastCopilotStudioRef, mcsConversationId, cancellationToken);
+
+            // Store the Teams conversation reference so proactive messages can be sent back.
+            await _messageSender.StoreUserChannelReferenceAsync(turnContext.Activity, mcsConversationId, cancellationToken);
+
+            ConversationReference? latestCopilotStudioRef = null;
+            var assistantMessageSurfaced = false;
+            var resetDuringTurn = false;
+
+            for (var attempt = 1; attempt <= McsStreamMaxAttempts; attempt++)
+            {
+                try
+                {
+                    await foreach (IActivity activity in cpsClient.SendActivityAsync(activityToSend, cancellationToken))
+                    {
+                        latestCopilotStudioRef = activity.GetConversationReference();
+
+                        // Track whether we've already shown the user a real reply this turn.
+                        // Once we have, a later transport fault must NOT trigger a retry
+                        // (that would re-send the user's turn and double-post).
+                        if (activity.IsType(ActivityTypes.Message) || activity.IsType(ActivityTypes.InvokeResponse))
+                        {
+                            assistantMessageSurfaced = true;
+                        }
+
+                        var reset = await ProcessCopilotStudioActivityAsync(
+                            turnContext, turnState, activity, mcsConversationId, cancellationToken);
+                        if (reset)
+                        {
+                            resetDuringTurn = true;
+                            break; // conversation was reset; stop processing further CPS activities.
+                        }
+                    }
+
+                    break; // stream completed successfully
+                }
+                catch (Exception ex) when (IsTransientStreamFault(ex) && !cancellationToken.IsCancellationRequested)
+                {
+                    if (assistantMessageSurfaced || attempt >= McsStreamMaxAttempts)
+                    {
+                        _logger.LogError(
+                            ex,
+                            "Copilot Studio stream failed for conversation {ConversationId} on attempt {Attempt}/{MaxAttempts} " +
+                            "(assistantMessageSurfaced={Surfaced}). Surfacing fallback message.",
+                            mcsConversationId, attempt, McsStreamMaxAttempts, assistantMessageSurfaced);
+
+                        await turnContext.SendActivityAsync(CopilotStreamErrorMessage, cancellationToken: cancellationToken);
+                        break;
+                    }
+
+                    var delay = TimeSpan.FromMilliseconds(McsStreamBaseDelay.TotalMilliseconds * Math.Pow(2, attempt - 1));
+                    _logger.LogWarning(
+                        ex,
+                        "Transient Copilot Studio stream reset for conversation {ConversationId} on attempt {Attempt}/{MaxAttempts}. " +
+                        "Retrying in {DelayMs} ms.",
+                        mcsConversationId, attempt, McsStreamMaxAttempts, (int)delay.TotalMilliseconds);
+
+                    await Task.Delay(delay, cancellationToken);
+                }
+            }
+
+            if (latestCopilotStudioRef != null && !resetDuringTurn)
+            {
+                _stateManager.SetLastCopilotStudioReference(turnState, latestCopilotStudioRef);
+            }
+        }
+
+        /// <summary>
+        /// True when the exception represents a transient transport-level fault on the
+        /// Copilot Studio SSE stream that is safe to retry at the connection level.
+        /// </summary>
+        private static bool IsTransientStreamFault(Exception ex)
+        {
+            for (var current = ex; current is not null; current = current.InnerException)
+            {
+                switch (current)
+                {
+                    case SocketException se
+                        when se.SocketErrorCode is SocketError.ConnectionReset
+                                                or SocketError.ConnectionAborted
+                                                or SocketError.TimedOut:
+                        return true;
+                    case IOException io when io.InnerException is SocketException:
+                        return true;
+                    case HttpRequestException:
+                        return true;
+                    case OperationCanceledException oce when !oce.CancellationToken.IsCancellationRequested:
+                        return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/samples/dotnet/genesys-handoff/GenesysHandoffAgent.cs
+++ b/samples/dotnet/genesys-handoff/GenesysHandoffAgent.cs
@@ -20,7 +20,7 @@ namespace GenesysHandoff
     /// <summary>
     /// An AgentApplication that integrates with Genesys for human handoff.
     /// </summary>
-    public class GenesysHandoffAgent : AgentApplication
+    public partial class GenesysHandoffAgent : AgentApplication
     {
         private const string McsHandlerName = "mcs";
 
@@ -190,71 +190,8 @@ namespace GenesysHandoff
             }
         }
 
-        /// <summary>
-        /// Handles starting a new conversation with Copilot Studio.
-        /// The last activity received from CPS is stored in conversation state so that
-        /// subsequent turns can be stitched to this conversation.
-        /// </summary>
-        private async Task<string> HandleNewConversation(ITurnContext turnContext, ITurnState turnState, Microsoft.Agents.CopilotStudio.Client.CopilotClient cpsClient, CancellationToken cancellationToken)
-        {
-            ConversationReference? lastCopilotStudioRef = null;
-
-            await foreach (IActivity activity in cpsClient.StartConversationAsync(emitStartConversationEvent: true, cancellationToken: cancellationToken))
-            {
-                _logger.LogInformation(
-                    "Activity from CPS (StartConversation): Id={CpsActivityId} ReplyToId={CpsReplyToId} Type={Type} Name={Name} Conversation={ConversationId}",
-                    activity.Id, activity.ReplyToId, activity.Type, activity.Name, activity.Conversation?.Id);
-                lastCopilotStudioRef = activity.GetConversationReference();
-                if (activity.IsType(ActivityTypes.Message))
-                {
-                    //var responseActivity = _responseProcessor.CreateResponseActivity(activity, "StartConversation");
-                  //await turnContext.SendActivityAsync(responseActivity, cancellationToken);
-                    if (!string.IsNullOrWhiteSpace(activity.Conversation?.Id))
-                    {
-                        _stateManager.SetConversationId(turnState, activity.Conversation.Id);
-                    }
-                }
-            }
-
-            if (lastCopilotStudioRef != null)
-            {
-                _stateManager.SetLastCopilotStudioReference(turnState, lastCopilotStudioRef);
-            }
-            
-            return lastCopilotStudioRef?.Conversation.Id ?? string.Empty;
-        }
-
-        /// <summary>
-        /// Handles processing messages through Copilot Studio and checking for escalation events.
-        /// The last activity received from CPS is stored in conversation state so that
-        /// subsequent turns can be stitched to this conversation.
-        /// </summary>
-        private async Task HandleCopilotStudioMessage(ITurnContext turnContext, ITurnState turnState, Microsoft.Agents.CopilotStudio.Client.CopilotClient cpsClient, string mcsConversationId, CancellationToken cancellationToken)
-        {
-            // When a message is received from the user, it is forwarded to Copilot Studio using the conversation ID stored in state.
-            // The agent then listens for responses from Copilot Studio. If a message activity is received, it is sent back to the user.
-            // If an event activity with the name "GenesysHandoff" is received, it indicates that the conversation should be escalated to a human agent through Genesys.
-            var lastCopilotStudioRef = _stateManager.GetLastCopilotStudioReference(turnState);
-            _logger.LogInformation(
-                "Activity from Teams: Id={TeamsActivityId} ReplyToId={TeamsReplyToId} Type={Type} Conversation={ConversationId}",
-                turnContext.Activity.Id, turnContext.Activity.ReplyToId, turnContext.Activity.Type, mcsConversationId);
-            var activityToSend = await BuildCopilotStudioActivityAsync(turnContext.Activity, lastCopilotStudioRef, mcsConversationId, cancellationToken);
-
-            // Store the Teams conversation reference so proactive messages (e.g. from the reset API) can be sent back.
-            await _messageSender.StoreUserChannelReferenceAsync(turnContext.Activity, mcsConversationId, cancellationToken);
-            ConversationReference? latestCopilotStudioRef = null;
-            await foreach (IActivity activity in cpsClient.SendActivityAsync(activityToSend, cancellationToken))
-            {
-                latestCopilotStudioRef = activity.GetConversationReference();
-                var result = await ProcessCopilotStudioActivityAsync(turnContext, turnState, activity, mcsConversationId, cancellationToken);
-                if (result) break; // If true is returned, it indicates the conversation has been reset and we should stop processing further CPS activities for this turn.
-            }
-
-            if (latestCopilotStudioRef != null)
-            {
-                _stateManager.SetLastCopilotStudioReference(turnState, latestCopilotStudioRef);
-            }
-        }
+        // HandleNewConversation and HandleCopilotStudioMessage are in
+        // GenesysHandoffAgent.Streaming.cs (resilient SSE streaming with retry).
 
         private async Task<bool> ProcessCopilotStudioActivityAsync(
             ITurnContext turnContext,

--- a/samples/dotnet/genesys-handoff/Program.cs
+++ b/samples/dotnet/genesys-handoff/Program.cs
@@ -11,11 +11,12 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Net.Http;
 using System.Threading;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddHttpClient();
+builder.Services.AddResilientMcsHttpClient();
 
 // Register IStorage.  For development, MemoryStorage is suitable.
 // For production Agents, persisted storage should be used so

--- a/samples/dotnet/genesys-handoff/README.md
+++ b/samples/dotnet/genesys-handoff/README.md
@@ -683,3 +683,47 @@ With the basics in place, you can use this foundation to further integrate and f
 8. **Agent disconnect detection (optional):** When `EnableNotifications` is enabled, the Agent SDK maintains a WebSocket connection to the Genesys Cloud Notification Service. Upon escalation, it subscribes to the `v2.detail.events.conversation.{id}.user.end` topic. When a Genesys agent disconnects, the Agent SDK proactively notifies the Teams user and clears the escalation flag on the next user message, returning the conversation to Copilot Studio.
 
 This architecture lets the user stay in a single Teams conversation while the Agent SDK, Copilot Studio runtime, Genesys Cloud, and persistent storage coordinate the escalation and message exchange behind the scenes. During escalation, Copilot Studio’s role is limited to raising the `GenesysHandoff` event; the actual Genesys conversation is managed directly between the Agent SDK and Genesys Cloud.
+
+---
+
+## Production Hardening
+
+This sample is a demonstration starting point. Before deploying to production, address the following:
+
+### SSE Streaming Resilience
+
+The Copilot Studio SSE stream can be reset by idle-sensitive intermediaries (SNAT, nginx, island-gateway) during long generative turns (~10s+ silence on the wire). The `GenesysHandoffAgent.Streaming.cs` partial class wraps the SSE enumeration with retry-with-backoff and a friendly fallback message. The `McsHttpClientRegistration` configures the `"mcs"` HttpClient with HTTP/2 keep-alive pings to prevent most resets.
+
+### Azure Blob Storage RBAC
+
+If using Azure Blob Storage for `ConversationMappingStore`, the app's managed identity **must** have the **Storage Blob Data Contributor** role on the storage account. Without this, you will see recurring `Azure.RequestFailedException 403 AuthorizationFailure` errors on `ConversationMappingStore.LoadAsync`, which can trigger a Genesys notification WebSocket reconnect storm.
+
+To fix:
+```bash
+az role assignment create \
+  --assignee <app-managed-identity-object-id> \
+  --role "Storage Blob Data Contributor" \
+  --scope /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Storage/storageAccounts/<account>
+```
+
+### MSAL Token Cache
+
+The default configuration uses an in-memory MSAL token cache. For production multi-instance deployments, configure a distributed token cache (e.g., Redis):
+
+```csharp
+builder.Services.AddDistributedMemoryCache(); // Replace with Redis in production
+// Or: builder.Services.AddStackExchangeRedisCache(options => { ... });
+```
+
+Without this, each instance independently acquires tokens, increasing latency and AAD throttling risk.
+
+### Persistent Storage
+
+Replace `MemoryStorage` with a persistent `IStorage` implementation (e.g., Azure Cosmos DB, Azure Blob Storage) so conversation state survives app restarts and works correctly across multiple instances:
+
+```csharp
+// Replace:
+builder.Services.AddSingleton<IStorage, MemoryStorage>();
+// With (example):
+builder.Services.AddSingleton<IStorage>(new CosmosDbPartitionedStorage(cosmosOptions));
+```

--- a/samples/dotnet/genesys-handoff/Services/McsHttpClientRegistration.cs
+++ b/samples/dotnet/genesys-handoff/Services/McsHttpClientRegistration.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Configures the named "mcs" HttpClient used by CopilotClientFactory with
+// keep-alive pings and appropriate handler lifetime to prevent idle-intermediary
+// TCP resets during long Copilot Studio SSE streaming reads.
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GenesysHandoff.Services
+{
+    public static class McsHttpClientRegistration
+    {
+        private const string McsHandlerName = "mcs";
+
+        public static IServiceCollection AddResilientMcsHttpClient(this IServiceCollection services)
+        {
+            // Preserve the default unnamed client used elsewhere in the app.
+            services.AddHttpClient();
+
+            services.AddHttpClient(McsHandlerName)
+                .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
+                {
+                    PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+                    PooledConnectionIdleTimeout = TimeSpan.FromMinutes(2),
+
+                    // Keep the outbound socket alive DURING an active SSE request.
+                    // Prevents idle-intermediary RSTs on long generative turns.
+                    KeepAlivePingDelay = TimeSpan.FromSeconds(15),
+                    KeepAlivePingTimeout = TimeSpan.FromSeconds(15),
+                    KeepAlivePingPolicy = HttpKeepAlivePingPolicy.WithActiveRequests,
+
+                    EnableMultipleHttp2Connections = true,
+                    ConnectTimeout = TimeSpan.FromSeconds(15),
+                })
+                // Do NOT let IHttpClientFactory recycle the handler mid-stream.
+                // Connection lifetime is managed by PooledConnectionLifetime above.
+                .SetHandlerLifetime(Timeout.InfiniteTimeSpan);
+
+            return services;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the recurring `Unable to read data from the transport connection: An existing connection was forcibly closed by the remote host.` error on long Copilot Studio generative turns in the genesys-handoff sample.

## Root Cause

The SSE stream enumeration (`SendActivityAsync` / `StartConversationAsync`) has no exception handling and no retry. On long generative turns (~10s+ silence on the wire), an idle-sensitive intermediary RSTs the outbound socket (SocketException 10054). The unguarded `IOException` propagates to the `CloudAdapter` default error handler, which leaks the raw transport error to the end user.

## Changes

| File | Change |
|------|--------|
| `GenesysHandoffAgent.Streaming.cs` (new) | Partial class with resilient `HandleNewConversation` and `HandleCopilotStudioMessage` — retry-with-backoff (3 attempts, 500ms exponential), idempotency guard (no retry after assistant reply surfaced), friendly fallback on exhaustion |
| `Services/McsHttpClientRegistration.cs` (new) | `AddResilientMcsHttpClient()` extension configuring the `mcs` HttpClient with `SocketsHttpHandler` keep-alive pings (15s, `WithActiveRequests`) and `SetHandlerLifetime(Infinite)` |
| `GenesysHandoffAgent.cs` | Marked class `partial`; removed unguarded streaming methods (moved to partial file) |
| `Program.cs` | Replaced `AddHttpClient()` with `AddResilientMcsHttpClient()` |
| `README.md` | Added Production Hardening section (Blob Storage RBAC, MSAL distributed cache, persistent IStorage) |

## Testing

- Build verified: 0 warnings, 0 errors
- No new package dependencies (retry is implemented inline)
